### PR TITLE
Fix: improve episode number match pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,8 +215,8 @@ autoload_local_danmaku=yes
 
 #### 功能说明
 
-保存哈希匹配的关联结果。启用时可以避免同番剧剧集的反复哈希匹配；禁用时始终进行哈希匹配（仅当同目录从未执行过手动搜索）
-可以应对边缘案例：同目录存在同一番剧的 OVA 和 MOVIE；同一番剧的剧集文件命名格式不同；同目录存在多个不同番剧。在这些情况下这些命名特殊无法获取到正确剧集数的文件可以通过保存哈希匹配结果加载其对应的弹幕。
+保存哈希匹配的弹幕关联结果。启用时可以避免同番剧不同剧集的反复哈希匹配；禁用时对同目录文件始终进行哈希匹配（仅当同目录从未执行过手动搜索）
+禁用时可以应对边缘案例：同目录存在同一番剧的 OVA 和 MOVIE；同一番剧的剧集文件命名格式不同；同目录存在多个不同番剧。在这些情况下这些命名特殊无法获取到正确剧集数的文件可以通过不保存哈希匹配的弹幕关联以始终对同目录文件执行哈希匹配以尝试加载其对应的弹幕。
 
 #### 使用方法
 
@@ -231,25 +231,25 @@ save_hash_match=yes
 #### 功能说明
 
 指定 DanmakuFactory 程序的路径，支持绝对路径和相对路径
-不特殊指定或者留空（默认值）会在脚本同目录的 bin 中查找，调用本人构建好的DanmakuFactory可执行文件
-示例：DanmakuFactory_Path = 'DanmakuFactory' 会在环境变量 PATH 中或 mpv 程序旁查找该程序
+不特殊指定或者留空（默认值）会在脚本同目录的 bin 中查找，调用本人构建好的 DanmakuFactory 可执行文件
+示例：`DanmakuFactory_Path=DanmakuFactory` 会在环境变量 PATH 中或 mpv 程序旁查找该程序
 
 #### 使用示例
 
 ```
-DanmakuFactory_Path="/path/to/your/DanmakuFactory"
+DanmakuFactory_Path=/path/to/your/DanmakuFactory
 ```
 
 ### history_path
 
 #### 功能说明
 
-指定弹幕关联历史记录文件的路径，支持绝对路径和相对路径。默认值是`"~~/danmaku-history.json"`也就是mpv配置文件夹的根目录下
+指定弹幕关联历史记录文件的路径，支持绝对路径和相对路径。默认值是`~~/danmaku-history.json`也就是mpv配置文件夹的根目录下
 
 #### 使用示例
 
 ```
-history_path="/path/to/your/danmaku-history.json"
+history_path=/path/to/your/danmaku-history.json
 ```
 
 ### DanmakuFactory相关配置（自定义弹幕样式相关配置）
@@ -258,27 +258,27 @@ history_path="/path/to/your/danmaku-history.json"
 
 ```
 #分辨率
-resolution="1920 1080"
+resolution=1920 1080
 #速度
-scrolltime="12"
+scrolltime=12
 #字体
-fontname="sans-serif"
+fontname=sans-serif
 #大小 
-fontsize="50"
+fontsize=50
 #透明度(1-255)  255 为不透明
-opacity="150"
+opacity=150
 #阴影
-shadow="0"
+shadow=0
 #粗体 true false
-bold="true"
+bold=true
 #弹幕密度 整数(>=-1) -1：表示不重叠 0：表示无限制 其他表示限定条数
-density="0.0"
+density=0.0
 #全部弹幕的显示范围(0.0-1.0)
-displayarea="0.85"
+displayarea=0.85
 #描边 0-4
-outline="1"
+outline=1
 #指定弹幕屏蔽词文件路径(black.txt)，支持绝对路径和相对路径。文件内容以换行分隔
-blacklist_path=""
+blacklist_path=
 ```
 
 ## 常见问题

--- a/api.lua
+++ b/api.lua
@@ -4,8 +4,8 @@ local options = {
     auto_load = false,
     autoload_local_danmaku = false,
     -- 保存哈希匹配的关联结果
-    -- 启用时可以避免同番剧剧集的反复哈希匹配
-    -- 禁用时始终进行哈希匹配（仅当同目录从未执行过手动搜索）；可以应对边缘案例：
+    -- 启用时可以避免同番剧不同剧集的反复哈希匹配
+    -- 禁用时对同目录文件始终进行哈希匹配（仅当同目录从未执行过手动搜索），这可以应对边缘案例：
     -- 同目录存在同一番剧的 OVA 和 MOVIE；同一番剧的剧集文件命名格式不同；同目录存在多个不同番剧
     save_hash_match = false,
     -- 指定 DanmakuFactory 程序的路径，支持绝对路径和相对路径
@@ -273,7 +273,7 @@ function get_episode_number(fname)
     -- 匹配模式：支持多种集数形式
     local patterns = {
         -- 匹配 [数字] 格式
-        "%[(%d+)%v?%d?]",
+        "%[(%d+)v?%d?%]",
         -- 匹配 S01E02 格式
         "[S%d+]?E(%d+)",
         -- 匹配 第04话 格式
@@ -281,9 +281,7 @@ function get_episode_number(fname)
         -- 匹配 -/# 第数字 格式
         "[-#]%s*(%d+)%s*",
         -- 匹配 直接跟随的数字 格式
-        "[^vV](%d+)[^pPkK][^%d]*$",
-        -- 匹配 直接跟随的数字 格式
-        "[^%d](%d+)[^%d]*",
+        "[^%dhHxXvV](%d%d%d?)[^%dpPkKxXbBfF][^%d]*$",
     }
 
     -- 尝试匹配文件名中的集数
@@ -308,12 +306,12 @@ end
 -- 写入history.json
 -- 读取episodeId获取danmaku
 function set_episode_id(input, from_menu)
-    local fname = mp.get_property('filename/no-ext')
     from_menu = from_menu or false
     local episodeId = tonumber(input)
     if options.auto_load and from_menu then
         local history = {}
         local dir = get_parent_directory()
+        local fname = mp.get_property('filename/no-ext')
         local episodeNumber = tonumber(episodeId) % 1000 --动漫的集数
         --将文件名:episodeId写入history.json
         if dir ~= nil then


### PR DESCRIPTION
调整后的正则匹配以应对以下文件命名：
```
Setoutsumi.01.2017.Amazon.WEB-DL.1080p.H264.DDP-HDCTV.mkv
Setoutsumi.01.2017.Amazon.WEB-DL.640x480.24fps.X265.10Bit.DDP-HDCTV.mkv
```
脚本配置文件中不能使用空格和引号