### PR TITLE
fix: autoload option supports runtime updates

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -863,27 +863,20 @@ function auto_load_danmaku(dir, filename)
     end
 end
 
-if options.auto_load then
-    mp.register_event("file-loaded", function()
-        local dir = get_parent_directory()
-        local filename = mp.get_property('filename/no-ext')
-        local danmaku_xml = utils.join_path(dir, filename .. ".xml")
-        if not options.autoload_local_danmaku or not file_exists(danmaku_xml) then
-            auto_load_danmaku(dir, filename)
-        end
-    end)
-end
-
-if options.autoload_local_danmaku then
-    mp.register_event("file-loaded", function()
-        local dir = get_parent_directory()
-        local filename = mp.get_property('filename/no-ext')
-        local danmaku_xml = utils.join_path(dir, filename .. ".xml")
+mp.register_event("file-loaded", function()
+    local dir = get_parent_directory()
+    local filename = mp.get_property('filename/no-ext')
+    local danmaku_xml = utils.join_path(dir, filename .. ".xml")
+    if options.autoload_local_danmaku then
         if file_exists(danmaku_xml) then
             load_local_danmaku(danmaku_xml)
+            return
         end
-    end)
-end
+    end
+    if options.auto_load then
+        auto_load_danmaku(dir, filename)
+    end
+end)
 
 mp.add_hook("on_unload", 50, function()
     local rm1 = utils.join_path(danmaku_path, "danmaku.json")


### PR DESCRIPTION
上次的 pr 总感觉漏了什么
在此之前已经添加过对选项运行时更新的支持：
https://github.com/Tony15246/uosc_danmaku/blob/29ea82deaac14e2f6521d52634b76c720fc65ff9/api.lua#L43

但由于 auto_load 选项相关代码实现没有支持此特性，修复
注意：一些选项（包括 auto_load）的更新在当前文件下无法触发，播放下一文件时才会生效