### PR TITLE
feat: implement autoload danmaku for URL videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,24 @@ auto_load=yes
 autoload_local_danmaku=yes
 ```
 
+### autoload_for_url
+
+#### 功能说明
+
+为可能支持的 url 视频文件实现弹幕关联记忆和继承，配合播放列表食用效果最佳
+
+> [!NOTE]
+>
+> 实验性功能，尚不完善
+
+#### 使用方法
+
+想要开启此选项，请在mpv配置文件夹下的`script-opts`中创建`uosc_danmaku.conf`文件并添加如下内容：
+
+```
+autoload_for_url=yes
+```
+
 ### save_hash_match
 
 #### 功能说明

--- a/main.lua
+++ b/main.lua
@@ -114,6 +114,7 @@ function open_input_menu()
         title = "在此处输入动画名称",
         search_style = "palette",
         search_debounce = "submit",
+        search_suggestion = get_title(true),
         on_search = { "script-message-to", mp.get_script_name(), "search-anime-event" },
         footnote = "使用enter或ctrl+enter进行搜索",
         items = {
@@ -225,7 +226,7 @@ mp.register_script_message("show_danmaku_keyboard", function()
 
     if sec_sid == "no" and has_danmaku == false then
         local path = mp.get_property("path")
-        local dir = get_parent_directory()
+        local dir = get_parent_directory(path)
         local filename = mp.get_property('filename/no-ext')
         if filename and dir then
             local danmaku_xml = utils.join_path(dir, filename .. ".xml")


### PR DESCRIPTION
示例：
- 与 [embyToLocalPlayer](https://github.com/kjtsune/embyToLocalPlayer) 结合使用

https://github.com/user-attachments/assets/a97e388a-5a26-423f-99ef-c97ecada4b06

- 与 [mpv-torrserver](https://github.com/dyphire/mpv-config/blob/master/scripts/mpv-torrserver.lua) 结合使用

https://github.com/user-attachments/assets/719080c2-a5a5-4358-bc95-4d1984a8d71c

也适用于其他网络播放场景
PS: 预先添加了 [tsukimi](https://github.com/tsukinaha/tsukimi) 预计将提供的`{} - S{}E{}: {}`的媒体标题格式的匹配模式