### PR TITLE
fix: episodeTitle log error

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -320,9 +320,15 @@ mp.register_script_message("show_danmaku_keyboard", function()
     end
 
     if sec_sid ~= "no" then
+        if danmaku.anime and danmaku.episode then
+            mp.osd_message("关闭弹幕：" .. danmaku.anime .. "-" .. danmaku.episode, 3)
+        end
         hide_danmaku_func()
         mp.commandv("script-message-to", "uosc", "set", "show_danmaku", "off")
     else
+        if danmaku.anime and danmaku.episode then
+            mp.osd_message("加载弹幕：" .. danmaku.anime .. "-" .. danmaku.episode, 3)
+        end
         show_danmaku_func()
         mp.commandv("script-message-to", "uosc", "set", "show_danmaku", "on")
     end


### PR DESCRIPTION
由于json文件中存储的episodeTitle在自动加载弹幕的时候不会随着加载的集数变化而变化，所以显示错误。比如说下面GBC的第二集显示成了第一集的标题
![screenshot_03112024_195204](https://github.com/user-attachments/assets/1c9202aa-51b7-4a92-80ca-4a6751a74c05)

之前采取的方法是在获取弹幕相关的数据时保存下动画和剧集标题，这么做难以实现记录每一集的标题。我将代码回退到了主分支的两个commit之前，也即#35之前。重构了获取动画和剧集标题的逻辑，改成了使用动画的ID向弹弹play请求动画的元数据。