### PR TITLE
fix: url hash match error

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ autoload_for_url=yes
 > [!NOTE]
 >
 > User-Agent格式必须符合弹弹play的标准，否则无法成功请求。具体格式要求见[弹弹play官方文档](https://github.com/kaedei/dandanplay-libraryindex/blob/master/api/OpenPlatform.md#5user-agent)
+>
+> 若想提高URL播放的哈希匹配成功率，可以将此项设为`mpv`或浏览器的User-Agent
 
 ```
 user_agent=mpv_danmaku/1.0

--- a/api.lua
+++ b/api.lua
@@ -444,7 +444,9 @@ function get_video_data(url)
         "--header",
         "Range: bytes=0-16777215",
         "--output",
-        danmaku_path .. "temp.mp4",
+        utils.join_path(danmaku_path, "temp.mp4"),
+        "--user-agent",
+        options.user_agent,
         url,
     }
 
@@ -843,9 +845,17 @@ function get_danmaku_with_hash(file_name, file_path)
             msg.error("HTTP 请求失败：" .. res.stderr)
             return
         end
-        file_path = danmaku_path .. "temp.mp4"
+        file_path = utils.join_path(danmaku_path, "temp.mp4")
+        if not file_exists(file_path) then
+            return
+        end
     end
     -- 计算文件哈希
+    local file_info = utils.file_info(file_path)
+    if file_info and file_info.size < 16 * 1024 * 1024 then
+        msg.verbose("文件小于 16M，无法计算 hash")
+        return
+    end
     local file, error = io.open(normalize(file_path), 'rb')
     if error ~= nil then
         return msg.error(error)

--- a/main.lua
+++ b/main.lua
@@ -309,13 +309,15 @@ mp.register_script_message("show_danmaku_keyboard", function()
         local path = mp.get_property("path")
         local dir = get_parent_directory(path)
         local filename = mp.get_property('filename/no-ext')
-        if filename and dir then
-            local danmaku_xml = utils.join_path(dir, filename .. ".xml")
-            if file_exists(danmaku_xml) then
-                load_local_danmaku(danmaku_xml)
-            else
-                get_danmaku_with_hash(filename, path)
+        if filename then
+            if dir then
+                local danmaku_xml = utils.join_path(dir, filename .. ".xml")
+                if file_exists(danmaku_xml) then
+                    load_local_danmaku(danmaku_xml)
+                    return
+                end
             end
+            get_danmaku_with_hash(filename, path)
             addon_danmaku(path)
         end
         return


### PR DESCRIPTION
我在几个 emby 服务上测试了下新的网络数据获取功能，发现有的可以有的无法获取。未能正常获取时会导致哈希匹配报错
修复