### PR TITLE
Refactor: use `osd-overlay` for rendering danmaku instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@
     │   ├── DanmakuFactory
     │   └── DanmakuFactory.exe
     └── main.lua
+    └── md5.lua
+    └── render.lua
 ```
 ### 基本配置
 
@@ -129,6 +131,14 @@ j script-message show_danmaku_keyboard
 ```
 open_search_danmaku_menu_key=Ctrl+i
 show_danmaku_keyboard_key=i
+```
+
+#### 设置弹幕延迟（可选）
+
+可以通过快捷键绑定以下命令来调整弹幕延迟，单位：秒。可以为负数
+
+```
+key script-message danmaku-delay <seconds>
 ```
 
 #### 从弹幕源向当前弹幕添加新弹幕内容（可选）
@@ -305,6 +315,20 @@ user_agent=mpv_danmaku/1.0
 proxy=127.0.0.1:7890
 ```
 
+### transparency
+
+#### 功能说明
+
+自定义弹幕的透明度，0（不透明）到255（完全透明）。默认值：48
+
+#### 使用方法
+
+想要使用此选项，请在mpv配置文件夹下的`script-opts`中创建`uosc_danmaku.conf`文件并自定义如下内容：
+
+```
+transparency=48
+```
+
 ### DanmakuFactory_Path
 
 #### 功能说明
@@ -342,16 +366,12 @@ history_path=/path/to/your/danmaku-history.json
 想要配置此选项，请在mpv配置文件夹下的`script-opts`中创建`uosc_danmaku.conf`文件并添加类似如下内容：
 
 ```
-#分辨率
-resolution=1920 1080
 #速度
-scrolltime=12
+scrolltime=15
 #字体
 fontname=sans-serif
 #大小 
 fontsize=50
-#透明度(1-255)  255 为不透明
-opacity=150
 #阴影
 shadow=0
 #粗体 true false

--- a/options.lua
+++ b/options.lua
@@ -1,7 +1,7 @@
 local opt = require("mp.options")
 
 -- 选项
-local options = {
+options = {
     api_server = "https://api.dandanplay.net",
     load_more_danmaku = false,
     auto_load = false,
@@ -10,6 +10,8 @@ local options = {
     add_from_source = false,
     user_agent = "mpv_danmaku/1.0",
     proxy = "",
+    -- 透明度：0（不透明）到255（完全透明）
+    transparency = 0x30,
     -- 指定 DanmakuFactory 程序的路径，支持绝对路径和相对路径
     -- 留空（默认值）会在脚本同目录的 bin 中查找
     -- 示例：DanmakuFactory_Path = 'DanmakuFactory' 会在环境变量 PATH 中或 mpv 程序旁查找该程序
@@ -18,16 +20,12 @@ local options = {
     history_path = "~~/danmaku-history.json",
     open_search_danmaku_menu_key = "Ctrl+d",
     show_danmaku_keyboard_key = "j",
-    --分辨率
-    resolution = "1920 1080",
     --速度
-    scrolltime = "12",
+    scrolltime = "15",
     --字体
     fontname = "sans-serif",
     --大小 
     fontsize = "50",
-    --透明度(1-255)  255 为不透明
-    opacity = "150",
     --阴影
     shadow = "0",
     --粗体 true false
@@ -37,7 +35,7 @@ local options = {
     --全部弹幕的显示范围(0.0-1.0)
     displayarea = "0.85",
     --描边 0-4
-    outline = "1",
+    outline = "1.0",
     -- 指定不会显示在屏幕上的弹幕类型。使用“-”连接类型名称，例如“L2R-TOP-BOTTOM”。可用的类型包括：L2R,R2L,TOP,BOTTOM,SPECIAL,COLOR,REPEAT
     blockmode = "",
     --指定弹幕屏蔽词文件路径(black.txt)，支持绝对路径和相对路径。文件内容以换行分隔
@@ -45,5 +43,3 @@ local options = {
 }
 
 opt.read_options(options, mp.get_script_name(), function() end)
-
-return options

--- a/render.lua
+++ b/render.lua
@@ -1,0 +1,194 @@
+-- modified from https://github.com/rkscv/danmaku/blob/main/danmaku.lua
+
+local msg = require('mp.msg')
+
+local INTERVAL = 0.01
+local osd_width, osd_height, delay, pause = 0, 0, 0, true
+enabled, comments = false, nil
+
+-- 从时间字符串转换为秒数
+local function time_to_seconds(time_str)
+    local h, m, s = time_str:match("(%d+):(%d+):([%d%.]+)")
+    return tonumber(h) * 3600 + tonumber(m) * 60 + tonumber(s)
+end
+
+-- 提取 \move 参数 (x1, y1, x2, y2) 并返回
+local function parse_move_tag(text)
+    -- 匹配包括小数和负数在内的坐标值
+    local x1, y1, x2, y2 = text:match("\\move%((%-?[%d%.]+),%s*(%-?[%d%.]+),%s*(%-?[%d%.]+),%s*(%-?[%d%.]+)%)")
+    if x1 and y1 and x2 and y2 then
+        return tonumber(x1), tonumber(y1), tonumber(x2), tonumber(y2)
+    end
+    return nil
+end
+
+local function apply_moving_text(event, pos)
+    local x1, y1, x2, y2 = parse_move_tag(event.text)
+    if not x1 then
+        return string.format("{\\an8}%s", event.text)
+    end
+
+    -- 计算移动的时间范围
+    local duration = options.scrolltime
+    local progress = (pos - event.start_time - delay) / duration  -- 移动进度 [0, 1]
+
+    -- 计算当前坐标
+    local current_x = x1 + (x2 - x1) * progress
+    local current_y = y1 + (y2 - y1) * progress
+
+    -- 移除 \move 标签并应用当前坐标
+    local clean_text = event.text:gsub("\\move%(.-%)", "")
+    return string.format("{\\pos(%d,%d)\\an8}%s", current_x, current_y, clean_text)
+end
+
+-- 从 ASS 文件中解析样式和事件
+local function parse_ass(ass_path)
+    local ass_file = io.open(ass_path, "r")
+    if not ass_file then
+        return nil
+    end
+
+    local events = {}
+
+    for line in ass_file:lines() do
+        if line:match("^Dialogue:") then
+            local start_time, end_time, style, text = line:match("Dialogue:%s*[^,]*,%s*([^,]*),%s*([^,]*),%s*([^,]*),[^,]*,[^,]*,[^,]*,[^,]*,[^,]*,(.*)")
+            if start_time and end_time and text then
+                table.insert(events, {
+                    start_time = time_to_seconds(start_time),
+                    end_time = time_to_seconds(end_time),
+                    text = text:gsub("%s+$", ""),
+                })
+            end
+        end
+    end
+
+    ass_file:close()
+    return events
+end
+
+local overlay = mp.create_osd_overlay('ass-events')
+
+local function render()
+    local pos, err = mp.get_property_number('time-pos')
+    if err ~= nil then
+        return msg.error(err)
+    end
+
+    local fontname = options.fontname
+    local fontsize = options.fontsize
+
+    local width, height = 1920, 1080
+    local ratio = osd_width / osd_height
+    if width / height < ratio then
+        height = width / ratio
+        fontsize = options.fontsize - ratio * 2
+    end
+
+    local ass_events = {}
+    for _, event in ipairs(comments) do
+        if pos >= event.start_time + delay and pos <= event.end_time + delay then
+            local text = apply_moving_text(event, pos)
+
+            -- 构建 ASS 字符串
+            local ass_text = string.format("{\\fn%s\\fs%d\\c&HFFFFFF&\\alpha&H%x\\bord%s\\shad%s\\b%s\\q2}%s",
+                fontname, fontsize, options.transparency, options.outline, options.shadow, options.bold == "true" and "1" or "0", text)
+
+            table.insert(ass_events, ass_text)
+        end
+    end
+
+    overlay.res_x = width
+    overlay.res_y = height
+    overlay.data = table.concat(ass_events, '\n')
+    overlay:update()
+end
+
+local function show_loaded()
+    if danmaku.anime and danmaku.episode then
+        mp.osd_message(danmaku.anime .. "-" .. danmaku.episode .. "\n弹幕加载成功，共计" .. #comments .. "条弹幕", 3)
+        msg.info(danmaku.anime .. "-" .. danmaku.episode .. " 弹幕加载成功，共计" .. #comments .. "条弹幕")
+    else
+        mp.osd_message("弹幕加载成功，共计" .. #comments .. "条弹幕", 3)
+    end
+end
+
+local timer = mp.add_periodic_timer(INTERVAL, render, true)
+
+function parse_danmaku(ass_file_path, from_menu)
+    enabled = true
+    comments, err = parse_ass(ass_file_path)
+    if not comments then
+        msg.error("ASS 解析错误:", err)
+        return
+    end
+
+    if enabled then
+        if from_menu then
+            show_danmaku_func()
+            mp.commandv("script-message-to", "uosc", "set", "show_danmaku", "on")
+        elseif get_danmaku_visibility() then
+            show_danmaku_func()
+            mp.commandv("script-message-to", "uosc", "set", "show_danmaku", "on")
+        end
+        show_loaded()
+    end
+end
+
+function show_danmaku_func()
+    render()
+    if not pause then
+        timer:resume()
+    end
+    set_danmaku_visibility(true)
+end
+
+function hide_danmaku_func()
+    timer:kill()
+    overlay:remove()
+    set_danmaku_visibility(false)
+end
+
+mp.observe_property('osd-width', 'number', function(_, value) osd_width = value or osd_width end)
+mp.observe_property('osd-height', 'number', function(_, value) osd_height = value or osd_height end)
+mp.observe_property('pause', 'bool', function(_, value)
+    if value ~= nil then
+        pause = value
+    end
+    if enabled then
+        if pause then
+            timer:kill()
+        elseif comments ~= nil then
+            timer:resume()
+        end
+    end
+end)
+
+mp.add_hook("on_unload", 50, function()
+    mp.unobserve_property('pause')
+    comments, delay = nil, 0
+    timer:kill()
+    overlay:remove()
+end)
+
+mp.register_event('playback-restart', function(event)
+    if event.error then
+        return msg.error(event.error)
+    end
+    if enabled and comments ~= nil then
+        render()
+    end
+end)
+
+mp.register_script_message("danmaku-delay", function(number)
+    local value = tonumber(number)
+    if value == nil then
+        return msg.error('command danmaku-delay: invalid time')
+    end
+    delay = delay + value
+    if enabled and comments ~= nil then
+        render()
+    end
+    mp.osd_message('设置弹幕延迟: ' .. (delay * 1000) .. ' ms')
+end)
+


### PR DESCRIPTION
摆脱视频画幅限制，实现 #47 
不再依赖次字幕新特性，降低 mpv 最低版本要求（与 uosc 配合使用时）
不再占用字幕轨
改善弹幕平滑度