### PR TITLE
fix: show danmaku error

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -318,14 +318,14 @@ mp.register_event("file-loaded", function(event)
     if event.error then
         return msg.error(event.error)
     end
-    if enabled and comments == nil then
+    if get_danmaku_visibility() and comments == nil then
         init()
     end
 end)
 
 mp.register_script_message("show_danmaku_keyboard", function()
-    enabled = not enabled
-    if enabled then
+    set_danmaku_visibility(not get_danmaku_visibility())
+    if get_danmaku_visibility() then
         if comments == nil then
             init()
         else


### PR DESCRIPTION
解决重构弹幕渲染逻辑导致的弹幕开关显示问题

1. 用户之前如果设置弹幕为关闭，打开视频时会渲染出静止的弹幕

https://github.com/user-attachments/assets/a2d8279e-17f7-42ee-99d4-2ae9fe55c329

2. 关闭弹幕后，如果暂停再播放，弹幕就会重新打开

https://github.com/user-attachments/assets/31ba5958-ba2b-4098-856b-ffa2e114433b

3. 关闭弹幕后如果快进或者拖动进度条，弹幕就会重新打开


https://github.com/user-attachments/assets/e5b42ad8-238c-4169-931d-875e5980d160

