### PR TITLE
fix: solve timer initialize problem on linux

### DIFF
--- a/render.lua
+++ b/render.lua
@@ -108,6 +108,8 @@ local function render()
     overlay:update()
 end
 
+local timer = mp.add_periodic_timer(INTERVAL, render, true)
+
 local function show_loaded()
     if danmaku.anime and danmaku.episode then
         mp.osd_message("匹配内容：" .. danmaku.anime .. "-" .. danmaku.episode .. "\n弹幕加载成功，共计" .. #comments .. "条弹幕", 3)
@@ -156,12 +158,10 @@ mp.observe_property('display-fps', 'number', function(_, value)
     if value ~= nil then
         local interval = 1 / value / 10
         if interval > INTERVAL then
+            timer:kill()
             timer = mp.add_periodic_timer(interval, render, true)
-        else
-            timer = mp.add_periodic_timer(INTERVAL, render, true)
+            timer:resume()
         end
-    else
-        timer = mp.add_periodic_timer(INTERVAL, render, true)
     end
 end)
 mp.observe_property('pause', 'bool', function(_, value)


### PR DESCRIPTION
修复linux上由于timer无法正确初始化导致的弹幕无法关闭的问题，顺便简化了根据帧率重设timer的fallback

经测试此初始化方法在windows上也能正确运行，根据帧率重设timer也正常