### PR TITLE
fix: add back high fps fallback for timer

### DIFF
--- a/render.lua
+++ b/render.lua
@@ -161,6 +161,10 @@ mp.observe_property('display-fps', 'number', function(_, value)
             timer:kill()
             timer = mp.add_periodic_timer(interval, render, true)
             timer:resume()
+        else
+            timer:kill()
+            timer = mp.add_periodic_timer(INTERVAL, render, true)
+            timer:resume()
         end
     end
 end)


### PR DESCRIPTION
解决#70 中显示器变帧率高时没还原计时器的问题