### PR TITLE
feat: add `merge_tolerance` option to allow merging of duplicate danmaku

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,22 @@ proxy=127.0.0.1:7890
 transparency=48
 ```
 
+### merge_tolerance
+
+#### 功能说明
+
+指定合并重复弹幕的时间间隔的容差值，单位为秒。默认值: -1，表示禁用
+
+当值设为0时会合并同一时间相同内容的弹幕，值大于0时会合并指定秒数误差内的相同内容的弹幕
+
+#### 使用方法
+
+想要使用此选项，请在mpv配置文件夹下的`script-opts`中创建`uosc_danmaku.conf`文件并自定义如下内容：
+
+```
+merge_tolerance=1
+```
+
 ### DanmakuFactory_Path
 
 #### 功能说明

--- a/api.lua
+++ b/api.lua
@@ -933,13 +933,6 @@ function load_danmaku_for_bilibili(path)
     if danmaku_id ~= nil then
         mp.commandv('sub-remove', danmaku_id)
     end
-    if path:match("^https://www.bilibili.com/video/BV.-") then
-        if path:match("video/BV.-/.*") then
-            path = path:gsub("/[^/]+$", "")
-        end
-        add_danmaku_source_online(path)
-        return
-    end
 
     if cid == nil then
         cid = mp.get_opt('cid')
@@ -962,6 +955,13 @@ function load_danmaku_for_bilibili(path)
                 end
             end
         end
+    end
+    if cid == nil and path:match("/video/BV.-") then
+        if path:match("video/BV.-/.*") then
+            path = path:gsub("/[^/]+$", "")
+        end
+        add_danmaku_source_online(path)
+        return
     end
     if cid ~= nil then
         local url = "https://comment.bilibili.com/" .. cid .. ".xml"

--- a/options.lua
+++ b/options.lua
@@ -12,6 +12,8 @@ options = {
     proxy = "",
     -- 透明度：0（不透明）到255（完全透明）
     transparency = 0x30,
+    -- 指定合并重复弹幕的时间间隔的容差值，单位为秒。默认值: -1，表示禁用
+    merge_tolerance = -1,
     -- 指定 DanmakuFactory 程序的路径，支持绝对路径和相对路径
     -- 留空（默认值）会在脚本同目录的 bin 中查找
     -- 示例：DanmakuFactory_Path = 'DanmakuFactory' 会在环境变量 PATH 中或 mpv 程序旁查找该程序

--- a/render.lua
+++ b/render.lua
@@ -16,7 +16,7 @@ end
 -- 提取 \move 参数 (x1, y1, x2, y2) 并返回
 local function parse_move_tag(text)
     -- 匹配包括小数和负数在内的坐标值
-    local x1, y1, x2, y2 = text:match("\\move%((%-?[%d%.]+),%s*(%-?[%d%.]+),%s*(%-?[%d%.]+),%s*(%-?[%d%.]+)%)")
+    local x1, y1, x2, y2 = text:match("\\move%((%-?[%d%.]+),%s*(%-?[%d%.]+),%s*(%-?[%d%.]+),%s*(%-?[%d%.]+).*%)")
     if x1 and y1 and x2 and y2 then
         return tonumber(x1), tonumber(y1), tonumber(x2), tonumber(y2)
     end
@@ -26,7 +26,11 @@ end
 local function apply_moving_text(event, pos)
     local x1, y1, x2, y2 = parse_move_tag(event.text)
     if not x1 then
-        return string.format("{\\an8}%s", event.text)
+        if event.style ~= "SP" and event.style ~= "MSG" then
+            return string.format("{\\an8}%s", event.text)
+        else
+            return string.format("{\\an7}%s", event.text)
+        end
     end
 
     -- 计算移动的时间范围
@@ -39,7 +43,11 @@ local function apply_moving_text(event, pos)
 
     -- 移除 \move 标签并应用当前坐标
     local clean_text = event.text:gsub("\\move%(.-%)", "")
-    return string.format("{\\pos(%d,%d)\\an8}%s", current_x, current_y, clean_text)
+    if event.style ~= "SP" and event.style ~= "MSG" then
+        return string.format("{\\pos(%.1f,%.1f)\\an8}%s", current_x, current_y, clean_text)
+    else
+        return string.format("{\\pos(%.1f,%.1f)\\an7}%s", current_x, current_y, clean_text)
+    end
 end
 
 -- 从 ASS 文件中解析样式和事件
@@ -50,19 +58,53 @@ local function parse_ass(ass_path)
     end
 
     local events = {}
+    local time_tolerance = options.merge_tolerance
 
     for line in ass_file:lines() do
         if line:match("^Dialogue:") then
             local start_time, end_time, style, text = line:match("Dialogue:%s*[^,]*,%s*([^,]*),%s*([^,]*),%s*([^,]*),[^,]*,[^,]*,[^,]*,[^,]*,[^,]*,(.*)")
+
             if start_time and end_time and text then
-                table.insert(events, {
+                local event = {
                     start_time = time_to_seconds(start_time),
                     end_time = time_to_seconds(end_time),
+                    style = style,
                     text = text:gsub("%s+$", ""),
-                })
+                    clean_text = text:gsub("\\pos%(.-%)", ""):gsub("\\move%(.-%)", ""),
+                    pos = text:match("\\pos"),
+                    move = text:match("\\move"),
+                }
+
+                local merged = false
+                for _, existing_event in ipairs(events) do
+                    if existing_event.clean_text == event.clean_text and
+                       math.abs(existing_event.start_time - event.start_time) <= time_tolerance then
+                        if (existing_event.style == event.style) or
+                        (existing_event.pos == event.pos) or (existing_event.move == event.move) then
+                            existing_event.end_time = math.max(existing_event.end_time, event.end_time)
+                            existing_event.count = (existing_event.count or 1) + 1
+                            if not existing_event.text:find("{\\b1\\i1}x%d+$") then
+                                existing_event.text = existing_event.text .. "{\\b1\\i1}x" .. existing_event.count
+                            else
+                                existing_event.text = existing_event.text:gsub("x%d+$", "x" .. existing_event.count)
+                            end
+                            merged = true
+                            break
+                        end
+                    end
+                end
+
+                if not merged then
+                    event.count = 1
+                    table.insert(events, event)
+                end
             end
         end
     end
+
+    table.sort(events, function(a, b)
+        return a.start_time < b.start_time
+    end)
 
     ass_file:close()
     return events
@@ -94,9 +136,15 @@ local function render()
         if pos >= event.start_time + delay and pos <= event.end_time + delay then
             local text = apply_moving_text(event, pos)
 
+            if text:match("\\fs%d+") then
+                local font_size = text:match("\\fs(%d+)") * 1.5
+                text = text:gsub("\\fs%d+", string.format("\\fs%s", font_size))
+            end
+
             -- 构建 ASS 字符串
             local ass_text = string.format("{\\fn%s\\fs%d\\c&HFFFFFF&\\alpha&H%x\\bord%s\\shad%s\\b%s\\q2}%s",
-                fontname, fontsize, options.transparency, options.outline, options.shadow, options.bold == "true" and "1" or "0", text)
+                fontname, text:match("{\\b1\\i1}x%d+$") and fontsize + text:match("x(%d+)$") or fontsize,
+                options.transparency, options.outline, options.shadow, options.bold == "true" and "1" or "0", text)
 
             table.insert(ass_events, ass_text)
         end
@@ -220,4 +268,3 @@ mp.register_script_message("danmaku-delay", function(number)
     end
     mp.osd_message('设置弹幕延迟: ' .. (delay * 1000) .. ' ms')
 end)
-


### PR DESCRIPTION
添加新的重复弹幕处理方式，原有的 blockmode 会移除常规弹幕中的所有重复内容

优化 ass 标签处理，实现部分特殊弹幕的渲染支持

在测试 b 站高级弹幕的时候发现弹弹play 接口会自动过滤高级弹幕，将此获取方式改成和巴哈一样的回退处理