### PR TITLE
misc: add clear-source osd output

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -1169,6 +1169,7 @@ mp.register_script_message("clear-source", function ()
         if path and history[path] ~= nil then
             history[path] = nil
             write_json_file(history_path, history)
+            mp.osd_message("已清空当前视频所关联的弹幕源", 3)
         end
     end
 end)


### PR DESCRIPTION
之前实现功能的时候忘记添加message输出，导致用户可能无法判断功能是否执行