### PR TITLE
feat: add source menu enhancement #88

### DIFF
--- a/options.lua
+++ b/options.lua
@@ -7,7 +7,6 @@ options = {
     auto_load = false,
     autoload_local_danmaku = false,
     autoload_for_url = false,
-    add_from_source = false,
     save_danmaku = false,
     user_agent = "mpv_danmaku/1.0",
     proxy = "",


### PR DESCRIPTION
增强了`从源添加弹幕`菜单的功能，使得可以通过该菜单可视化地管理所有弹幕源，顺便完成了#88中的需求

Close #88

1. 删除用户添加的弹幕源

![screenshot_13012025_163743](https://github.com/user-attachments/assets/05f39ee0-f136-4010-8ccc-2642f28d26f1)

2. 屏蔽来自弹幕服务器的弹幕源
![screenshot_13012025_163025](https://github.com/user-attachments/assets/1c7cfb8b-d66e-4f66-b285-024e1d194852)

3. 解除对来自弹幕服务器的弹幕源的屏蔽
![screenshot_13012025_163058](https://github.com/user-attachments/assets/393a9953-81b9-423e-995c-b34db5c5ab6f)

另外，由于`add_from_source`选项是弹幕源管理不透明的情况下的产物，现在用户已经可以通过该菜单进行方便的可视化弹幕源管理，因此将该可选配置项废除
