### PR TITLE
fix: solve clear-source fail problem and solve fontname encode problem #111

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -837,7 +837,7 @@ function convert_with_danmaku_factory(danmaku_input, danmaku_out)
         "-i",
         "--ignore-warnings",
         "--scrolltime", options.scrolltime,
-        "--fontname", options.fontname,
+        "--fontname", "sans-serif",
         "--fontsize", options.fontsize,
         "--shadow", options.shadow,
         "--bold", options.bold,
@@ -1262,11 +1262,15 @@ mp.register_script_message("clear-source", function ()
         if path and history[path] ~= nil then
             history[path] = nil
             write_json_file(history_path, history)
-            for url, source in ipairs(danmaku.sources) do
+            for url, source in pairs(danmaku.sources) do
                 if source.from == "user_custom" then
+                    if source.fname and file_exists(source.fname) then
+                        os.remove(source.fname)
+                    end
                     danmaku.sources[url] = nil
                 end
             end
+            load_danmaku(false)
             show_message("已清空当前视频所关联的弹幕源", 3)
         end
     end

--- a/main.lua
+++ b/main.lua
@@ -623,6 +623,10 @@ mp.register_script_message('menu-event', function(json)
     if event.type == 'activate' then
 
         if event.action == "delete" then
+            local rm = danmaku.sources[event.value]["fname"]
+            if rm and file_exists(rm) then
+                os.remove(rm)
+            end
             danmaku.sources[event.value] = nil
             remove_source_from_history(event.value)
             mp.commandv("script-message-to", "uosc", "close-menu", "menu_source")


### PR DESCRIPTION
Close #111

1. 修正了clear-source功能中误用ipairs导致的nil problem
2. 固定了ass文件中存储的字体名，以避免非英文字符编码问题