### PR TITLE
feat: add new api support

### DIFF
--- a/extra.lua
+++ b/extra.lua
@@ -1,0 +1,365 @@
+local utils = require 'mp.utils'
+local msg = require 'mp.msg'
+
+local Source = {
+    ["b 站"] = "bilibili1",
+    ["腾讯"] = "qq",
+    ["爱奇艺"] = "qiyi",
+    ["优酷"] = "youku",
+}
+
+local function is_chinese(str)
+    return string.match(str, "[\228-\233][\128-\191]") ~= nil
+end
+
+local function load_extra_danmaku(url, episode, number, class, id, site, title, year)
+    local play_url = nil
+    if url:match("^.-%.html") then
+        play_url = url:match("^(.-%.html).*")
+    else
+        play_url = url:gsub("%?bsource=360ogvys$","")
+    end
+    danmaku.anime = title .. " (" .. year .. ")"
+    danmaku.episode = "第" .. episode .. "话"
+    danmaku.source = site
+    danmaku.extra = {}
+    danmaku.extra.id = id
+    danmaku.extra.site = site
+    danmaku.extra.year = year
+    danmaku.extra.class = class
+    danmaku.extra.title = title
+    danmaku.extra.number = number
+    danmaku.extra.episodenum = episode
+    write_history()
+    add_danmaku_source(play_url, true)
+end
+
+local function query_tmdb_movies(title, menu)
+    local encoded_title = url_encode(title)
+    local url = string.format("https://api.themoviedb.org/3/search/movie?api_key=%s&query=%s&language=zh-CN",
+    options.tmdb_api_key, encoded_title)
+
+    local cmd = {
+        "curl",
+        "-s",
+        "-H", "accept: application/json",
+        url
+    }
+
+    local res = mp.command_native({
+        name = "subprocess",
+        args = cmd,
+        capture_stdout = true,
+        capture_stderr = true,
+    })
+
+    if res.status ~= 0 then
+        local message = "获取 tmdb 中文数据失败"
+        if uosc_available then
+            update_menu_uosc(menu.type, menu.title, message, menu.footnote, menu.cmd, title)
+        else
+            show_message(message, 3)
+        end
+        msg.error("获取 tmdb 中文数据失败：" .. res.stderr)
+    end
+
+    local data = utils.parse_json(res.stdout)
+    if data and data.results and #data.results > 0 then
+        return data.results[1].title
+    end
+end
+
+local function query_tmdb_tv(title, menu)
+    local encoded_title = url_encode(title)
+    local url = string.format("https://api.themoviedb.org/3/search/tv?api_key=%s&query=%s&language=zh-CN",
+    options.tmdb_api_key, encoded_title)
+
+    local cmd = {
+        "curl",
+        "-s",
+        "-H", "accept: application/json",
+        url
+    }
+
+    local res = mp.command_native({
+        name = "subprocess",
+        args = cmd,
+        capture_stdout = true,
+        capture_stderr = true,
+    })
+
+    if res.status ~= 0 then
+        local message = "获取 tmdb 中文数据失败"
+        if uosc_available then
+            update_menu_uosc(menu.type, menu.title, message, menu.footnote, menu.cmd, title)
+        else
+            show_message(message, 3)
+        end
+        msg.error("获取 tmdb 中文数据失败：" .. res.stderr)
+    end
+
+    local data = utils.parse_json(res.stdout)
+    if data and data.results and #data.results > 0 then
+        return data.results[1].name
+    end
+end
+
+local function get_episode_number(cat, id, site)
+    local url = string.format("https://api.web.360kan.com/v1/detail?cat=%s&id=%s&site=%s",
+        cat, id, site)
+
+    local cmd = { "curl", "-s", url }
+    local res = mp.command_native({
+        name = "subprocess",
+        args = cmd,
+        capture_stdout = true,
+        capture_stderr = true,
+    })
+
+    if res.status ~= 0 then
+        msg.error("Failed to fetch data: " .. (res.stderr or "unknown error"))
+        return nil
+    end
+
+    local result = utils.parse_json(res.stdout)
+    if result and result.data and result.data.allupinfo then
+        return tonumber(result.data.allupinfo[site])
+    end
+    return nil
+end
+
+function get_details(class, id, site, title, year, number, episodenum)
+    local message = episodenum and "查询弹幕中..." or "加载数据中..."
+    local menu_type = "menu_details"
+    local menu_title = "剧集信息"
+    local footnote = "使用 / 打开筛选"
+    if uosc_available and not episodenum then
+        update_menu_uosc(menu_type, menu_title, message, footnote)
+    else
+        show_message(message, 3)
+    end
+
+    local cat = 0
+    if class == "电影" then
+        cat = 1
+    elseif class == "电视剧" then
+        cat = 2
+--  elseif class == "综艺" then
+--      cat = 3
+    elseif class == "动漫" then
+        cat = 4
+    end
+
+    if not number and cat ~= 0 then
+        number = get_episode_number(cat, id, site)
+    end
+    if not number or cat == 0 then
+        local message = "无结果"
+        if uosc_available and not episodenum then
+            update_menu_uosc(menu_type, menu_title, message, footnote)
+        else
+            show_message(message, 3)
+        end
+        msg.verbose("无结果")
+        return
+    end
+
+    local url = string.format("https://api.web.360kan.com/v1/detail?cat=%s&id=%s&start=1&end=%s&site=%s",
+        cat, id, number, site)
+
+    local cmd = { "curl", "-s", url }
+    local res = mp.command_native({
+        name = "subprocess",
+        args = cmd,
+        capture_stdout = true,
+        capture_stderr = true,
+    })
+
+    if res.status ~= 0 then
+        local message = "无结果"
+        if uosc_available and not episodenum then
+            update_menu_uosc(menu_type, menu_title, message, footnote)
+        else
+            show_message(message, 3)
+        end
+        msg.verbose("无结果")
+        return
+    end
+
+    local result = utils.parse_json(res.stdout)
+    local items = {}
+    if result and result.data and result.data.allepidetail then
+        local data = result.data.allepidetail
+        local playurl, episode = nil, nil
+        if episodenum then
+            for _, item in ipairs(data[site]) do
+                if tonumber(item.playlink_num) == tonumber(episodenum) then
+                    playurl = item.url
+                    episode = item.playlink_num
+                    break
+                end
+            end
+            if playurl then
+                load_extra_danmaku(playurl, episode, number, class, id, site, title, year)
+                return
+            end
+        end
+        for _, item in ipairs(data[site]) do
+            table.insert(items, {
+                title = "第" .. item.playlink_num .. "集",
+                hint = item.playlink_num,
+                value = {
+                    "script-message-to",
+                    mp.get_script_name(),
+                    "add-extra-event",
+                    item.url, item.playlink_num, number, class, id, site, title, year
+                },
+            })
+        end
+    end
+    if #items > 0 then
+        if uosc_available and not episodenum then
+            update_menu_uosc(menu_type, menu_title, items, footnote)
+        elseif not episodenum then
+            show_message("", 0)
+            mp.add_timeout(0.1, function()
+                open_menu_select(items)
+            end)
+        end
+    else
+        local message = "无结果"
+        if uosc_available and not episodenum then
+            update_menu_uosc(menu_type, menu_title, message, footnote)
+        else
+            show_message(message, 3)
+        end
+        msg.verbose("无结果")
+    end
+end
+
+local function search_query(query, class, menu)
+    local url = string.format("https://api.so.360kan.com/index?force_v=1&kw=%s", query)
+    if class ~= nil then
+        url = url .. "&type=" .. class
+    end
+    local cmd = { "curl", "-s", url }
+
+    local res = mp.command_native({
+        name = "subprocess",
+        args = cmd,
+        capture_stdout = true,
+        capture_stderr = true,
+    })
+
+    if res.status ~= 0 then
+        local message = "无结果"
+        if uosc_available then
+            update_menu_uosc(menu.type, menu.title, message, menu.footnote, menu.cmd, query)
+        else
+            show_message(message, 3)
+        end
+        msg.verbose("无结果")
+        return
+    end
+
+    local result = utils.parse_json(res.stdout)
+    local items = {}
+    if result and result.data.longData and result.data.longData.rows then
+        for _, item in ipairs(result.data.longData.rows) do
+            if item.playlinks then
+                for source_name, source_id in pairs(Source) do
+                    if item.playlinks[source_id] then
+                        table.insert(items, {
+                            title = item.titleTxt,
+                            hint = item.cat_name .. " | " .. item.year .. " | 来源：" .. source_name,
+                            value = {
+                                "script-message-to",
+                                mp.get_script_name(),
+                                "get-extra-event",
+                                item.cat_name, item.en_id, utils.format_json(item.playlinks), source_id,
+                                item.titleTxt, item.year,
+                            },
+                        })
+                    end
+                end
+            end
+        end
+    end
+    if #items > 0 then
+        if uosc_available then
+            update_menu_uosc(menu.type, menu.title, items, menu.footnote, menu.cmd, query)
+        else
+            show_message("", 0)
+            mp.add_timeout(0.1, function()
+                open_menu_select(items)
+            end)
+        end
+    else
+        local message = "无结果"
+        if uosc_available then
+            update_menu_uosc(menu.type, menu.title, message, menu.footnote, menu.cmd, query)
+        else
+            show_message(message, 3)
+        end
+        msg.verbose("无结果")
+    end
+end
+
+function query_extra(name, class)
+    local title = nil
+    local class = class and class:lower()
+    local menu = {}
+    local message = "加载数据中..."
+    menu.type = "menu_anime"
+    menu.title = "在此处输入番剧名称"
+    menu.footnote = "使用enter或ctrl+enter进行搜索"
+    menu.cmd = { "script-message-to", mp.get_script_name(), "search-anime-event" }
+    if uosc_available then
+        update_menu_uosc(menu.type, menu.title, message, menu.footnote, menu.cmd, name)
+    else
+        show_message(message, 30)
+    end
+
+    if is_chinese(name) then
+        search_query(name, class, menu)
+        return
+    end
+
+    if class == "dy" then
+        title = query_tmdb_movies(name, menu)
+    else
+        title = query_tmdb_tv(name, menu)
+    end
+
+    if title then
+        search_query(title, class)
+    end
+end
+
+mp.register_script_message("get-extra-event", function(cat, id, playlinks, source_id, title, year)
+    if uosc_available then
+        mp.commandv("script-message-to", "uosc", "close-menu", "menu_anime")
+    end
+    if cat == "电影" then
+        local playlinks = utils.parse_json(playlinks)
+        if playlinks[source_id]:match("^.-%.html") then
+            play_url = playlinks[source_id]:match("^(.-%.html).*")
+        else
+            play_url = playlinks[source_id]:gsub("%?bsource=360ogvys$","")
+        end
+        danmaku.anime = title .. " (" .. year .. ")"
+        danmaku.episode = "电影"
+        danmaku.source = "extra"
+        write_history()
+        add_danmaku_source(play_url, true)
+    else
+        get_details(cat, id, source_id, title, year)
+    end
+end)
+
+mp.register_script_message("add-extra-event", function(url, episode, number, class, id, site, title, year)
+    if uosc_available then
+        mp.commandv("script-message-to", "uosc", "close-menu", "menu_details")
+    end
+    load_extra_danmaku(url, episode, number, class, id, site, title, year)
+end)

--- a/options.lua
+++ b/options.lua
@@ -3,6 +3,9 @@ local opt = require("mp.options")
 -- 选项
 options = {
     api_server = "https://api.dandanplay.net",
+    -- 设置 tmdb 的 API Key，用于获取非动画条目的中文信息(当搜索内容非中文时)
+    -- 请在 https://www.themoviedb.org 注册后去个人账号设置界面获取
+    tmdb_api_key= "",
     load_more_danmaku = false,
     auto_load = false,
     autoload_local_danmaku = false,

--- a/render.lua
+++ b/render.lua
@@ -281,7 +281,8 @@ function show_message(text, time)
     message_timer.timeout = time or 3
     message_timer:kill()
     message_overlay:remove()
-    local message = string.format("{\\an%d\\pos(%d,%d)}%s", options.message_anlignment, options.message_x, options.message_y, text)
+    local message = string.format("{\\an%d\\pos(%d,%d)}%s", options.message_anlignment,
+       options.message_x, options.message_y, text)
     local width, height = 1920, 1080
     local ratio = osd_width / osd_height
     if width / height < ratio then


### PR DESCRIPTION
基于 #121 

实现 https://github.com/Tony15246/uosc_danmaku/issues/114#issuecomment-2606517060 中的部分想法

通过在搜索关键词后追加`|ds`, `|dy`和`|dm`等额外关键词触发新的 API 弹幕搜索（对应电视剧、电影、动漫）
它会获取弹弹play 的 API 支持解析的视频网站的对应播放链接，然后再通过调用弹弹play 的 API 来获取弹幕
PS：动漫不推荐使用它，弹弹play 的 api 要更强大（国漫的话可以使用它，更全）

~~还有些小细节待完善~~

功能示意：

https://github.com/user-attachments/assets/21add67b-2269-450c-8562-63d4bfde4da6

API 文档参考：https://www.eruyi.cn/thread-11578-1-1.html