### PR TITLE
fix: clear api sever source when reset episode

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -412,6 +412,14 @@ end
 function set_episode_id(input, from_menu)
     from_menu = from_menu or false
     danmaku.source = "dandanplay"
+    for url, source in pairs(danmaku.sources) do
+        if source.from == "api_server" then
+            if source.fname and file_exists(source.fname) then
+                os.remove(source.fname)
+            end
+            danmaku.sources[url] = nil
+        end
+    end
     local episodeId = tonumber(input)
     if from_menu and options.auto_load or options.autoload_for_url then
         write_history(episodeId)

--- a/main.lua
+++ b/main.lua
@@ -783,7 +783,7 @@ mp.register_script_message('setup-danmaku-source', function(json)
 
         if event.action == "delete" then
             local rm = danmaku.sources[event.value]["fname"]
-            if rm and file_exists(rm) then
+            if rm and file_exists(rm) and danmaku.sources[event.value]["from"] ~= "user_local" then
                 os.remove(rm)
             end
             danmaku.sources[event.value] = nil


### PR DESCRIPTION
解决此处提到的 https://github.com/Tony15246/uosc_danmaku/issues/120#issuecomment-2629301010 重新搜索弹幕并加载时没清空旧弹幕的问题