### PR TITLE
feat: add support for new time input format and hide blocked sources in delay menu

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -417,7 +417,10 @@ function set_episode_id(input, from_menu)
             if source.fname and file_exists(source.fname) then
                 os.remove(source.fname)
             end
-            danmaku.sources[url] = nil
+
+            if not source.from_history then
+                danmaku.sources[url] = nil
+            end
         end
     end
     local episodeId = tonumber(input)
@@ -570,7 +573,7 @@ function fetch_danmaku(episodeId, from_menu)
         local response = utils.parse_json(res.stdout)
         if response and response["comments"] then
             if response["count"] == 0 then
-                if danmaku.sources["-" .. url] == nil then
+                if danmaku.sources[url] == nil then
                     danmaku.sources[url] = {from = "api_server"}
                 end
                 show_message("该集弹幕内容为空，结束加载", 3)
@@ -651,7 +654,7 @@ function fetch_danmaku_all(episodeId, from_menu)
             end
 
             if #comments == 0 then
-                if danmaku.sources["-" .. related["url"]] == nil then
+                if danmaku.sources[related["url"]] == nil then
                     danmaku.sources[related["url"]] = {from = "api_server"}
                 end
             else
@@ -694,7 +697,7 @@ function fetch_danmaku_all(episodeId, from_menu)
     local count = response["count"]
 
     if count == 0 then
-        if danmaku.sources["-" .. url] == nil then
+        if danmaku.sources[url] == nil then
             danmaku.sources[url] = {from = "api_server"}
         end
         load_danmaku(from_menu)
@@ -1067,6 +1070,7 @@ function read_danmaku_source_record(path)
                 if source:match("^-") then
                     source = source:sub(2)
                     blocked = true
+                    from = "api_server"
                 end
                 if from then
                     source = source:gsub("<" .. from .. ">", "")
@@ -1080,15 +1084,18 @@ function read_danmaku_source_record(path)
                 if blocked then
                     danmaku.sources[source]["blocked"] = true
                 end
-                if from then
-                    danmaku.sources[source]["from"] = from
-                end
+
+                danmaku.sources[source]["from"] = from or "user_custom"
+
                 if delay then
                     danmaku.sources[source]["delay"] = delay
                 end
+
+                danmaku.sources[source]["from_history"] = true
             end
         end
     end
+
 end
 
 -- 为 bilibli 网站的视频播放加载弹幕
@@ -1372,7 +1379,7 @@ mp.register_script_message("clear-source", function ()
                 end
             end
             load_danmaku(false)
-            show_message("已清空当前视频所关联的弹幕源", 3)
+            show_message("已重置当前视频所有弹幕源更改", 3)
         end
     end
 end)

--- a/main.lua
+++ b/main.lua
@@ -409,7 +409,7 @@ function danmaku_delay_setup(source_url)
 
     local sources = {}
     for url, source in pairs(danmaku.sources) do
-        if source.fname then
+        if source.fname and not source.blocked then
             local item = {title = url, value = url, keep_open = true,}
             item.hint = "当前弹幕源延迟:" .. (source.delay and tostring(source.delay) or "0.0") .. "秒"
             item.active = url == source_url
@@ -425,7 +425,7 @@ function danmaku_delay_setup(source_url)
         callback = {mp.get_script_name(), 'setup-source-delay'},
     }
     if source_url ~= nil then
-        menu_props.title = "请输入一位小数，单位（秒）"
+        menu_props.title = "请输入数字，单位（秒）/ 或者按照形如\"14m15s\"的格式输入分钟数加秒数"
         menu_props.search_style = "palette"
         menu_props.search_debounce = "submit"
         menu_props.on_search = { "script-message-to", mp.get_script_name(), "setup-source-delay", source_url }
@@ -831,6 +831,15 @@ mp.register_script_message("setup-source-delay", function(query, text)
         if tonumber(newText) ~= nil then
             local num = tonumber(newText)
             danmaku.sources[query]["delay"] = tostring(num)
+            add_source_to_history(query, danmaku.sources[query])
+            mp.commandv("script-message-to", "uosc", "close-menu", "menu_delay")
+            danmaku_delay_setup(query)
+            load_danmaku(true, true)
+        elseif newText:match("^%d+m%d+s$") then
+            local minutes, seconds = string.match(newText, "^(%d+)m(%d+)s$")
+            minutes = tonumber(minutes)
+            seconds = tonumber(seconds)
+            danmaku.sources[query]["delay"] = tostring(60 * minutes + seconds)
             add_source_to_history(query, danmaku.sources[query])
             mp.commandv("script-message-to", "uosc", "close-menu", "menu_delay")
             danmaku_delay_setup(query)


### PR DESCRIPTION
https://github.com/Tony15246/uosc_danmaku/issues/120#issuecomment-2629214656
https://github.com/Tony15246/uosc_danmaku/issues/120#issuecomment-2629215925

完成以上两个需求，顺便解决 #147 引入的，盲目清空所有弹幕服务器弹幕源，导致历史记录中保存的延迟失效的bug