### PR TITLE
fix: ensure danmaku visibility regardless of OSD options

### DIFF
--- a/render.lua
+++ b/render.lua
@@ -202,7 +202,7 @@ local function render()
             end
 
             -- 构建 ASS 字符串
-            local ass_text = text and string.format("{\\fn%s\\fs%d\\c&HFFFFFF&\\alpha&H%x\\bord%s\\shad%s\\b%s\\q2}%s",
+            local ass_text = text and string.format("{\\fn%s\\fs%d\\c&HFFFFFF&\\3c&H000000&\\4c&H000000&\\alpha&H%x\\bord%s\\shad%s\\b%s\\q2}%s",
                 fontname, text:match("{\\b1\\i1}x%d+$") and fontsize + text:match("x(%d+)$") or fontsize,
                 options.transparency, options.outline, options.shadow, options.bold == "true" and "1" or "0", text)
 


### PR DESCRIPTION
## Change
- Hardcoded the outline color and shadow color to black (`\3c&H000000&\4c&H000000&`) in the subtitle rendering string.

## Description
弹幕描边和阴影颜色受`--osd-outline-color`（`--osd-border-color`）和`--osd-back-color`（`--osd-shadow-color`）控制。  

例如，在配合 mpv-lazy（[2024V3(EX)](https://github.com/hooke007/MPV_lazy/releases/tag/20241229)）使用的的情况下，由于 mpv-lazy 默认在 mpv.conf 中配置了`osd-border-color = "#FFFFFF"`，导致弹幕描边也变为白色，如图：
![MPV_00-02-13 508_01](https://github.com/user-attachments/assets/44499690-6742-412e-a9ae-ca1986a12856)

因此我希望直接指定描边颜色和阴影颜色，以避免OSD参数预期外的影响。

因为我没有自由修改颜色的需求，就直接采取硬编码ASS标签这样不太优雅的办法了（