### PR TITLE
fix: duplicate danmaku filename when fallback

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -491,8 +491,9 @@ function get_danmaku_fallback(query)
 
     local url = options.fallback_server .. "/?url=" .. query
     msg.verbose("尝试获取弹幕：" .. url)
-    local temp_file = "danmaku-" .. pid .. ".xml"
+    local temp_file = "danmaku-" .. pid .. danmaku.count .. ".xml"
     local danmaku_xml = utils.join_path(danmaku_path, temp_file)
+    danmaku.count = danmaku.count + 1
     local arg = {
         "curl",
         "-L",
@@ -1280,8 +1281,9 @@ function load_danmaku_for_bilibili(path)
     end
     if cid ~= nil then
         local url = "https://comment.bilibili.com/" .. cid .. ".xml"
-        local temp_file = "danmaku-" .. pid .. ".xml"
+        local temp_file = "danmaku-" .. pid .. danmaku.count .. ".xml"
         local danmaku_xml = utils.join_path(danmaku_path, temp_file)
+        danmaku.count = danmaku.count + 1
         local arg = {
             "curl",
             "-L",
@@ -1367,8 +1369,9 @@ function load_danmaku_for_bahamut(path)
             return
         end
 
-        local temp_file = "danmaku-" .. pid .. ".json"
+        temp_file = "danmaku-" .. pid .. danmaku.count .. ".json"
         local json_filename = utils.join_path(danmaku_path, temp_file)
+        danmaku.count = danmaku.count + 1
         local json_file = io.open(json_filename, "w")
 
         if json_file then

--- a/render.lua
+++ b/render.lua
@@ -366,9 +366,8 @@ mp.add_hook("on_unload", 50, function()
     local danmaku_path = os.getenv("TEMP") or "/tmp/"
     local rm1 = utils.join_path(danmaku_path, "danmaku-" .. pid .. ".json")
     local rm2 = utils.join_path(danmaku_path, "danmaku-" .. pid .. ".ass")
-    local rm3 = utils.join_path(danmaku_path, "danmaku-" .. pid .. ".xml")
-    local rm4 = utils.join_path(danmaku_path, "temp-" .. pid .. ".mp4")
-    local rm5 = utils.join_path(danmaku_path, "bahamut-" .. pid .. ".json")
+    local rm3 = utils.join_path(danmaku_path, "temp-" .. pid .. ".mp4")
+    local rm4 = utils.join_path(danmaku_path, "bahamut-" .. pid .. ".json")
     if file_exists(rm1) then os.remove(rm1) end
     if file_exists(rm2) then
         if options.save_danmaku then
@@ -378,7 +377,6 @@ mp.add_hook("on_unload", 50, function()
     end
     if file_exists(rm3) then os.remove(rm3) end
     if file_exists(rm4) then os.remove(rm4) end
-    if file_exists(rm5) then os.remove(rm5) end
     for _, source in pairs(danmaku.sources) do
         if source.fname and source.from and source.from ~= "user_local" and file_exists(source.fname) then
             os.remove(source.fname)


### PR DESCRIPTION
由于不只是电影电视剧，正常的从源添加弹幕有时也会回落到`get_danmaku_fallback`函数。而由于`get_danmaku_fallback`设置的弹幕文件名的重复，会导致新fallback到`get_danmaku_fallback`函数获取的弹幕，会覆盖之前别的fallback的弹幕源的弹幕。因此添加了count作为唯一标识，避免弹幕文件名重复。