### PR TITLE
fix: matched negative delay

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -274,7 +274,7 @@ function read_danmaku_source_record(path)
                     source = source:gsub("<" .. from .. ">", "")
                 end
                 if delay then
-                    source = source:gsub("{{" .. delay .. "}}", "")
+                    source = source:gsub("{{%-?" .. delay .. "}}", "")
                 end
 
                 danmaku.sources[source] = {}


### PR DESCRIPTION
修复弹幕源延迟在负数情况下，因为读取history文件后 `source` 里的 `delay` 删不干净而造成的源名称错误