### PR TITLE
fix: danmaku of iqiyi's source was not correctly handled

### DIFF
--- a/apis/dandanplay.lua
+++ b/apis/dandanplay.lua
@@ -57,6 +57,9 @@ function get_danmaku_fallback(query)
             return
         end
         if file_exists(danmaku_xml) then
+            if query:find("iqiyi%.com") ~= nil then
+                danmaku.strict = true
+            end
             save_danmaku_downloaded(query, danmaku_xml)
             load_danmaku(true)
         end

--- a/main.lua
+++ b/main.lua
@@ -415,7 +415,7 @@ function convert_with_danmaku_factory(danmaku_input, danmaku_out, delays, callba
 
     local shift = 1
 
-    if options.font_size_strict == "true" then
+    if options.font_size_strict == "true" or danmaku.strict then
         table.insert(arg, 13, "--font-size-strict")
     end
 


### PR DESCRIPTION
另见 https://github.com/hihkm/DanmakuFactory/pull/106

这不适用于本地 xml 文件，若遇到此类弹幕文件用户依然需要手动启用选项修复