### PR TITLE
优化弹幕延迟的显示格式

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -857,7 +857,7 @@ mp.register_script_message("danmaku-delay", function(number)
     if enabled and comments ~= nil then
         render()
     end
-    show_message('设置弹幕延迟: ' .. delay .. ' s')
+    show_message('设置弹幕延迟: ' .. string.format("%.1f", delay + 1e-10) .. ' s')
     mp.set_property_native(delay_property, delay)
 end)
 

--- a/modules/menu.lua
+++ b/modules/menu.lua
@@ -418,7 +418,7 @@ function danmaku_delay_setup(source_url)
     for url, source in pairs(danmaku.sources) do
         if source.fname and not source.blocked then
             local item = {title = url, value = url, keep_open = true,}
-            item.hint = "当前弹幕源延迟:" .. (source.delay and tostring(source.delay) or "0.0") .. "秒"
+            item.hint = "当前弹幕源延迟:" .. (source.delay and string.format("%.1f", source.delay + 1e-10) or "0.0") .. "秒"
             item.active = url == source_url
             table.insert(sources, item)
         end


### PR DESCRIPTION
由于浮点运算的精度损失，多次调整延迟时可能会出现 `2.7755575615629e-17` 这样的异常显示。

另外，`+1e-10` 是为了防止 `-0.0` 的情况出现。