### PR TITLE
fix: solve query_tmdb movie failure

### DIFF
--- a/apis/extra.lua
+++ b/apis/extra.lua
@@ -298,7 +298,7 @@ function query_extra(name, class)
     end
 
     if class == "dy" then
-        title = query_tmdb(name, "moive", menu)
+        title = query_tmdb(name, "movie", menu)
     else
         title = query_tmdb(name, "tv", menu)
     end


### PR DESCRIPTION
修复拼写错误导致的tmdb电影数据api请求失败