### PR TITLE
Optimize README.md layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@
     └── render.lua
 ```
 
-### 基本配置
+## 基本配置
 
 #### uosc控件配置
 
@@ -110,8 +110,8 @@
 
 由于uosc最近才更新了部分接口和控件代码，导致老旧版本的uosc和新版的uosc配置有所不同。如果是下载的最新git版uosc或者一直保持更新的用户按照[最新版uosc的控件配置步骤](#最新版uosc的控件配置步骤)配置即可。如果不确定自己的uosc版本，或者在使用诸如[MPV_lazy](https://github.com/hooke007/MPV_lazy)等由第三方管理uosc版本的用户，可以使用兼容新版和旧版uosc的[旧版uosc控件配置步骤](#旧版uosc控件配置步骤)
 
-##### 最新版uosc的控件配置步骤
-
+<details>
+<summary>最新版uosc的控件配置步骤</summary>
 找到 `uosc.conf`文件中的 `controls`配置项，uosc官方默认的配置可能如下：
 
 ```
@@ -123,8 +123,10 @@ controls=menu,gap,subtitles,<has_many_audio>audio,<has_many_video>video,<has_man
 ```
 controls=menu,gap,subtitles,<has_many_audio>audio,<has_many_video>video,<has_many_edition>editions,<stream>stream-quality,button:danmaku,cycle:toggle_on:show_danmaku@uosc_danmaku:on=toggle_on/off=toggle_off?弹幕开关,gap,space,speed,space,shuffle,loop-playlist,loop-file,gap,prev,items,next,gap,fullscreen
 ```
+</details>
 
-##### 旧版uosc控件配置步骤
+<details>
+<summary>旧版uosc控件配置步骤</summary>
 
 找到 `uosc.conf`文件中的 `controls`配置项，uosc官方默认的配置可能如下：
 
@@ -137,10 +139,14 @@ controls=menu,gap,subtitles,<has_many_audio>audio,<has_many_video>video,<has_man
 ```
 controls=menu,gap,subtitles,<has_many_audio>audio,<has_many_video>video,<has_many_edition>editions,<stream>stream-quality,command:search:script-message open_search_danmaku_menu?搜索弹幕,cycle:toggle_on:show_danmaku@uosc_danmaku:on=toggle_on/off=toggle_off?弹幕开关,gap,space,speed,space,shuffle,loop-playlist,loop-file,gap,prev,items,next,gap,fullscreen
 ```
+</details>
 
-##### 修改uosc控件（可选）
+<details>
+<summary>修改uosc控件（可选）</summary>
 
 如果出于重名等各种原因，无法将本插件所放置的文件夹命名为 `uosc_danmaku`的话，需要修改 `cycle:toggle_on:show_danmaku@uosc_danmaku:on=toggle_on/off=toggle_off?弹幕开关`的弹幕开关配置中的 `uosc_danmaku`为放置本插件的文件夹的名称。假如将本插件放置在 `my_folder`文件夹下，那么弹幕开关配置就要修改为 `cycle:toggle_on:show_danmaku@my_folder:on=toggle_on/off=toggle_off?弹幕开关`
+</details>
+
 
 #### 绑定快捷键（可选）
 
@@ -165,7 +171,18 @@ open_search_danmaku_menu_key=Ctrl+i
 show_danmaku_keyboard_key=i
 ```
 
-#### 从弹幕源向当前弹幕添加新弹幕内容（可选）
+## 拓展功能（可选）
+
+本插件针对弹幕有丰厚的拓展功能
+
+---
+
+**带控件的功能**
+
+<details>
+<summary>从弹幕源向当前弹幕添加新弹幕内容</summary>
+ 
+> #### 从弹幕源向当前弹幕添加新弹幕内容（可选）
 
 从弹幕源添加弹幕。在已经在播放弹幕的情况下会将添加的弹幕追加到现有弹幕中。
 
@@ -198,8 +215,12 @@ C:\Users\Tony\Downloads\example.xml
 ```
 
 现已更新增强了此菜单。现在在该菜单内可以可视化地控制所有弹幕源，删除或者屏蔽任何不想要的弹幕源。对于自己手动添加的弹幕源，可以进行移除。对于来自弹弹play的弹幕源，无法进行移除，但是可以进行屏蔽，将不会再从屏蔽过的弹幕源获取弹幕。当然，也可以解除对来自弹弹play的弹幕源的屏蔽。另外需要注意在菜单内对于弹幕源的可视化操作都需要下次打开视频，或者重新用弹幕搜索功能加载一次弹幕才会生效。
+</details>
 
-#### 弹幕源延迟设置
+<details>
+<summary>弹幕源延迟设置</summary>
+
+> #### 弹幕源延迟设置（可选）
 
 可以独立控制每个弹幕源的延迟，延迟支持两种输入模式。第一种模式为输入数字（最高可精确到小数点后两位），单位为秒；第二种输入模式为输入形如 `14m15s`格式的字符串，代表延迟的分钟数和秒数。
 
@@ -210,8 +231,12 @@ C:\Users\Tony\Downloads\example.xml
 ```
 key script-message open_source_delay_menu
 ```
+</details>
 
-#### 实时修改弹幕样式（可选）
+<details>
+<summary> 实时修改弹幕样式</summary>
+
+> #### 实时修改弹幕样式（可选）
 
 依赖于[uosc UI框架](https://github.com/tomasklaen/uosc)实现**弹幕样式实时修改**，将打开弹幕样式修改图形化菜单供用户手动修改，该功能目前仅依靠 uosc 实现（uosc不可用时无法使用此功能，并默认使用[自定义弹幕样式](#DanmakuFactory相关配置自定义弹幕样式相关配置)里的样式配置）。想要启用此功能，需要参照[uosc控件配置](#uosc控件配置)，根据uosc版本添加 `button:danmaku_styles`或 `command:palette:script-message open_setup_danmaku_menu?弹幕样式`到 `uosc.conf`的controls配置项中。
 
@@ -220,8 +245,12 @@ key script-message open_source_delay_menu
 ```
 key script-message open_setup_danmaku_menu
 ```
+</details>
 
-#### 弹幕设置（可选）
+<details>
+<summary> 弹幕设置总菜单</summary>
+
+> #### 弹幕设置总菜单（可选）
 
 打开多级功能复合菜单，包含了插件目前所有的图形化功能。想要启用此功能，需要参照[uosc控件配置](#uosc控件配置)，根据uosc版本添加 `button:danmaku_menu`或 `command:grid_view:script-message open_add_total_menu?弹幕设置`到 `uosc.conf`的controls配置项中。
 
@@ -230,8 +259,16 @@ key script-message open_setup_danmaku_menu
 ```
 key script-message open_add_total_menu
 ```
+</details>
 
-#### 设置弹幕延迟（可选）
+---
+
+**仅快捷键的功能**
+
+<details>
+<summary>设置弹幕延迟</summary>
+
+> #### 设置弹幕延迟（可选）
 
 可以通过快捷键绑定以下命令来调整弹幕延迟，单位：秒。可以为负数
 
@@ -240,8 +277,12 @@ key script-message danmaku-delay <seconds>
 ```
 
 > 当前弹幕延迟的值可以从 `user-data/uosc_danmaku/danmaku-delay`属性中获取到，具体用法可以参考[此issue](https://github.com/Tony15246/uosc_danmaku/issues/77)
+</details>
 
-#### 清空当前视频关联的弹幕源（可选）
+<details>
+<summary>清空当前视频关联的弹幕源</summary>
+
+> #### 清空当前视频关联的弹幕源（可选）
 
 可以清空当前视频中，用户通过[从源获取弹幕](#从弹幕源向当前弹幕添加新弹幕内容可选)菜单手动添加的所有弹幕源（注意该功能不会删除来源于弹幕服务器的弹幕，此类弹幕只能屏蔽或者手动重新匹配新弹幕库）。清空过弹幕源之后，下次播放该视频，就不会再加载之前手动添加过的弹幕源，可以重新添加弹幕源。
 
@@ -250,8 +291,12 @@ key script-message danmaku-delay <seconds>
 ```
 key script-message clear-source
 ```
+</details>
 
-#### 保存当前视频弹幕（可选）
+<details>
+<summary>保存当前视频弹幕</summary>
+
+> #### 保存当前视频弹幕（可选）
 
 在视频播放时手动保存弹幕至视频所在文件夹，保存格式为 `xml`（注：此功能将保存为视频同名弹幕，若视频文件夹下存在同名文件将不会执行该功能）
 
@@ -260,8 +305,14 @@ key script-message clear-source
 ```
 key script-message immediately_save_danmaku
 ```
+</details>
 
-## 配置选项（可选）
+## 可配置选项（可选）
+
+### 弹幕相关
+
+<details>
+<summary>api_server-自定义弹幕API</summary>
 
 ### api_server
 
@@ -280,6 +331,10 @@ key script-message immediately_save_danmaku
 ```
 api_server=https://api.dandanplay.net
 ```
+</details>
+
+<details>
+<summary>load_more_danmaku-获取所有弹幕源加载</summary>
 
 ### load_more_danmaku
 
@@ -296,6 +351,10 @@ api_server=https://api.dandanplay.net
 ```
 load_more_danmaku=yes
 ```
+</details>
+
+<details>
+<summary>auto_load-全自动弹幕填装</summary>
 
 ### auto_load
 
@@ -337,6 +396,10 @@ auto_load=yes
 ├── 少女歌剧4.mp4
 └── 哭泣少女乐队2.mp4
 ```
+</details>
+
+<details>
+<summary>autoload_local_danmaku-自动加载同目录下的xml格式弹幕文件</summary>
 
 ### autoload_local_danmaku
 
@@ -351,6 +414,10 @@ auto_load=yes
 ```
 autoload_local_danmaku=yes
 ```
+</details>
+
+<details>
+<summary>autoload_for_url-为url视频文件弹幕实现关联记忆和继承</summary>
 
 ### autoload_for_url
 
@@ -373,6 +440,10 @@ autoload_local_danmaku=yes
 ```
 autoload_for_url=yes
 ```
+</details>
+
+<details>
+<summary>add_from_source-记录通过 `从弹幕源向当前弹幕添加新弹幕内容`关联过的弹幕源并下次自动加载（已废除）</summary>
 
 ### add_from_source
 
@@ -391,6 +462,10 @@ autoload_for_url=yes
 ```
 add_from_source=yes
 ```
+</details>
+
+<details>
+<summary>save_danmaku-自动保存弹幕文件（xml格式）至视频同目录</summary>
 
 ### save_danmaku
 
@@ -415,6 +490,10 @@ add_from_source=yes
 ```
 save_danmaku=yes
 ```
+</details>
+
+<details>
+<summary>user_agent-自定义User Agent</summary>
 
 ### user_agent
 
@@ -435,6 +514,10 @@ save_danmaku=yes
 ```
 user_agent=mpv_danmaku/1.0
 ```
+</details>
+
+<details>
+<summary>proxy-自定义代理</summary>
 
 ### proxy
 
@@ -449,6 +532,10 @@ user_agent=mpv_danmaku/1.0
 ```
 proxy=127.0.0.1:7890
 ```
+</details>
+
+<details>
+<summary>vf_fps-使用fps视频滤镜提升弹幕平滑度（帧数）</summary>
 
 ### vf_fps
 
@@ -467,6 +554,10 @@ proxy=127.0.0.1:7890
 ```
 vf_fps=yes
 ```
+</details>
+
+<details>
+<summary>fps-自定义fps滤镜参数</summary>
 
 ### fps
 
@@ -483,6 +574,10 @@ vf_fps=yes
 ```
 fps=60/1.001
 ```
+</details>
+
+<details>
+<summary>transparency-自定义弹幕的透明度</summary>
 
 ### transparency
 
@@ -497,6 +592,10 @@ fps=60/1.001
 ```
 transparency=48
 ```
+</details>
+
+<details>
+<summary>merge_tolerance-指定合并重复弹幕的时间间隔的容差值</summary>
 
 ### merge_tolerance
 
@@ -513,6 +612,10 @@ transparency=48
 ```
 merge_tolerance=1
 ```
+</details>
+
+<details>
+<summary>chConvert-中文简繁转换</summary>
 
 ### chConvert
 
@@ -527,6 +630,12 @@ merge_tolerance=1
 ```
 chConvert=0
 ```
+</details>
+
+### 配置相关
+
+<details>
+<summary>DanmakuFactory_Path-指定DanmakuFactory程序路径</summary>
 
 ### DanmakuFactory_Path
 
@@ -546,6 +655,10 @@ chConvert=0
 ```
 DanmakuFactory_Path=/path/to/your/DanmakuFactory
 ```
+</details>
+
+<details>
+<summary>OpenCC_Path-指定OpenCC程序路径</summary>
 
 ### OpenCC_Path
 
@@ -565,6 +678,10 @@ DanmakuFactory_Path=/path/to/your/DanmakuFactory
 ```
 OpenCC_Path=/path/to/your/opencc
 ```
+</details>
+
+<details>
+<summary>history_path-指定弹幕关联历史记录文件路径</summary>
 
 ### history_path
 
@@ -582,6 +699,10 @@ OpenCC_Path=/path/to/your/opencc
 ```
 history_path=/path/to/your/danmaku-history.json
 ```
+</details>
+
+<details>
+<summary>message_x-自定义插件相关提示的显示位置（x轴）</summary>
 
 ### message_x
 
@@ -596,6 +717,10 @@ history_path=/path/to/your/danmaku-history.json
 ```
 message_x=30
 ```
+</details>
+
+<details>
+<summary>message_y-自定义插件相关提示的显示位置（y轴）</summary>
 
 ### message_y
 
@@ -610,6 +735,10 @@ message_x=30
 ```
 message_y=30
 ```
+</details>
+
+<details>
+<summary>title_replace-自定义文件标题解析中的额外替换规则</summary>
 
 ### title_replace
 
@@ -622,6 +751,7 @@ message_y=30
 ```
 title_replace=[{"rules":[{ "^〔(.-)〕": "%1"},{ "^.*《(.-)》": "%1" }]}]
 ```
+</details>
 
 ### DanmakuFactory相关配置（自定义弹幕样式相关配置）
 

--- a/README.md
+++ b/README.md
@@ -329,7 +329,11 @@ key script-message immediately_save_danmaku
 ### 弹幕相关
 
 <details>
-<summary>api_server———自定义弹幕API</summary>
+<summary>
+api_server
+
+> 自定义弹幕API
+</summary>
 
 ### api_server
 
@@ -353,7 +357,11 @@ api_server=https://api.dandanplay.net
 ---
 
 <details>
-<summary>fallback_server———自定义b站和爱腾优的弹幕获取的兜底服务器地址</summary>
+<summary>
+fallback_server
+
+> 自定义b站和爱腾优的弹幕获取的兜底服务器地址
+</summary>
 
 ### fallback_server
 
@@ -378,7 +386,11 @@ fallback_server=https://fc.lyz05.cn
 ---
 
 <details>
-<summary>tmdb_api_key———设置 tmdb 的 API Key获取非动画条目的中文信息</summary>
+<summary>
+tmdb_api_key
+
+> 设置 tmdb 的 API Key获取非动画条目的中文信息
+</summary>
 
 ### tmdb_api_key
 
@@ -402,7 +414,11 @@ tmdb_api_key=NmJmYjIxOTZkNzIyN2UyMTIzMGM3Y2YzZjQ4MDNkZGM=
 ---
 
 <details>
-<summary>load_more_danmaku———开关是否全量弹幕源加载</summary>
+<summary>
+load_more_danmaku
+
+> 开关是否全量弹幕源加载
+</summary>
 
 ### load_more_danmaku
 
@@ -424,7 +440,11 @@ load_more_danmaku=yes
 ---
 
 <details>
-<summary>auto_load———开关是否全自动弹幕填装</summary>
+<summary>
+auto_load
+
+> 开关是否全自动弹幕填装
+</summary>
 
 ### auto_load
 
@@ -471,7 +491,11 @@ auto_load=yes
 ---
 
 <details>
-<summary>autoload_local_danmaku———开关是否自动加载同目录下的xml格式弹幕文件</summary>
+<summary>
+autoload_local_danmaku
+
+> 开关是否自动加载同目录下的xml格式弹幕文件
+</summary>
 
 ### autoload_local_danmaku
 
@@ -491,7 +515,11 @@ autoload_local_danmaku=yes
 ---
 
 <details>
-<summary>autoload_for_url———开关是否为url视频文件弹幕关联记忆和继承</summary>
+<summary>
+autoload_for_url
+
+> 开关是否为url视频文件弹幕关联记忆和继承
+</summary>
 
 ### autoload_for_url
 
@@ -519,7 +547,11 @@ autoload_for_url=yes
 ---
 
 <details>
-<summary>add_from_source———开关是否记录通过 从弹幕源向当前弹幕添加新弹幕内容 关联过的弹幕源并下次自动加载（已废除）</summary>
+<summary>
+add_from_source
+
+> 开关是否记录通过 从弹幕源向当前弹幕添加新弹幕内容 关联过的弹幕源并下次自动加载（已废除）
+</summary>
 
 ### add_from_source
 
@@ -543,7 +575,11 @@ add_from_source=yes
 ---
 
 <details>
-<summary>save_danmaku———开关是否自动保存弹幕文件（xml格式）至视频同目录</summary>
+<summary>
+save_danmaku
+
+> 开关是否自动保存弹幕文件（xml格式）至视频同目录
+</summary>
 
 ### save_danmaku
 
@@ -573,7 +609,11 @@ save_danmaku=yes
 ---
 
 <details>
-<summary>vf_fps———开关是否使用fps视频滤镜提升弹幕平滑度（帧数）</summary>
+<summary>
+vf_fps
+
+> 开关是否使用fps视频滤镜提升弹幕平滑度（帧数）
+</summary>
 
 ### vf_fps
 
@@ -597,7 +637,11 @@ vf_fps=yes
 ---
 
 <details>
-<summary>fps———自定义fps滤镜参数</summary>
+<summary>
+fps
+
+> 自定义fps滤镜参数
+</summary>
 
 ### fps
 
@@ -619,7 +663,11 @@ fps=60/1.001
 ---
 
 <details>
-<summary>transparency———自定义弹幕的透明度</summary>
+<summary>
+transparency
+
+> 自定义弹幕的透明度
+</summary>
 
 ### transparency
 
@@ -639,7 +687,11 @@ transparency=48
 ---
 
 <details>
-<summary>merge_tolerance———指定合并重复弹幕的时间间隔的容差值</summary>
+<summary>
+merge_tolerance
+
+> 指定合并重复弹幕的时间间隔的容差值
+</summary>
 
 ### merge_tolerance
 
@@ -661,7 +713,11 @@ merge_tolerance=1
 ---
 
 <details>
-<summary>chConvert———开关是否进行中文简繁转换</summary>
+<summary>
+chConvert
+
+> 开关是否进行中文简繁转换
+</summary>
 
 ### chConvert
 
@@ -683,7 +739,11 @@ chConvert=0
 ### 插件配置相关
 
 <details>
-<summary>user_agent———自定义User Agent</summary>
+<summary>
+user_agent
+
+> 自定义User Agent
+</summary>
 
 ### user_agent
 
@@ -709,7 +769,11 @@ user_agent=mpv_danmaku/1.0
 ---
 
 <details>
-<summary>proxy———自定义代理</summary>
+<summary>
+proxy
+
+> 自定义代理
+</summary>
 
 ### proxy
 
@@ -729,7 +793,11 @@ proxy=127.0.0.1:7890
 ---
 
 <details>
-<summary>DanmakuFactory_Path———指定DanmakuFactory程序路径</summary>
+<summary>
+DanmakuFactory_Path
+
+> 指定DanmakuFactory程序路径
+</summary>
 
 ### DanmakuFactory_Path
 
@@ -754,7 +822,11 @@ DanmakuFactory_Path=/path/to/your/DanmakuFactory
 ---
 
 <details>
-<summary>OpenCC_Path———指定OpenCC程序路径</summary>
+<summary>
+OpenCC_Path
+
+> 指定OpenCC程序路径
+</summary>
 
 ### OpenCC_Path
 
@@ -779,7 +851,11 @@ OpenCC_Path=/path/to/your/opencc
 ---
 
 <details>
-<summary>history_path———指定弹幕关联历史记录文件路径</summary>
+<summary>
+history_path
+
+> 指定弹幕关联历史记录文件路径
+</summary>
 
 ### history_path
 
@@ -802,7 +878,11 @@ history_path=/path/to/your/danmaku-history.json
 ---
 
 <details>
-<summary>message_x———自定义插件相关提示的显示位置（x轴）</summary>
+<summary>
+message_x
+
+> 自定义插件相关提示的显示位置（x轴）
+</summary>
 
 ### message_x
 
@@ -822,7 +902,11 @@ message_x=30
 ---
 
 <details>
-<summary>message_y———自定义插件相关提示的显示位置（y轴）</summary>
+<summary>
+message_y
+
+> 自定义插件相关提示的显示位置（y轴）
+</summary>
 
 ### message_y
 
@@ -842,7 +926,11 @@ message_y=30
 ---
 
 <details>
-<summary>title_replace———自定义文件标题解析中的额外替换规则</summary>
+<summary>
+title_replace
+
+> 自定义文件标题解析中的额外替换规则
+</summary>
 
 ### title_replace
 
@@ -917,3 +1005,4 @@ blacklist_path=
 ## 相关项目
 
 - [slqy123/uosc_danmaku](https://github.com/slqy123/uosc_danmaku) 本项目的fork版本，实现了通过dandanplay api发送弹幕的功能，由于版本的兼容性以及功能的易用性问题未被合并，具体讨论请参阅 [#220](https://github.com/Tony15246/uosc_danmaku/pull/220)
+

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@
 3. 通过点击加入uosc control bar中的弹幕开关控件可以控制弹幕的开关
 4. 通过点击加入uosc control bar中的[从源获取弹幕](#从弹幕源向当前弹幕添加新弹幕内容可选)按钮可以通过受支持的网络源或本地文件添加弹幕
 5. 通过点击加入uosc control bar中的[弹幕样式](#实时修改弹幕样式可选)按钮可以打开uosc弹幕样式菜单供用户在视频播放时实时修改弹幕样式（注意⚠️：未安装uosc框架时该功能不可用）
-6. 通过点击加入uosc control bar中的[弹幕设置](#弹幕设置可选)按钮可以打开多级功能复合菜单，包含了插件目前所有的图形化功能。
-7. 通过点击加入uosc control bar中的[弹幕源延迟设置](#弹幕源延迟设置)按钮可以打开弹幕源延迟控制菜单，可以独立控制每个弹幕源的延迟（注意⚠️：未安装uosc框架时该功能不可用）
+6. 通过点击加入uosc control bar中的[弹幕设置](#弹幕设置总菜单可选)按钮可以打开多级功能复合菜单，包含了插件目前所有的图形化功能。
+7. 通过点击加入uosc control bar中的[弹幕源延迟设置](#弹幕源延迟设置可选)按钮可以打开弹幕源延迟控制菜单，可以独立控制每个弹幕源的延迟（注意⚠️：未安装uosc框架时该功能不可用）
 8. 记忆型全自动弹幕填装，在为某个文件夹下的某一集番剧加载过一次弹幕后，加载过的弹幕会自动关联到该集；之后每次重新播放该文件就会自动加载弹幕，同时该文件对应的文件夹下的所有其他集数的文件都会在播放时自动加载弹幕，无需再重复手动输入番剧名进行搜索（注意⚠️：全自动弹幕填装默认关闭，如需开启请阅读[auto_load配置项说明](#auto_load)）
 9. 在没有手动加载过弹幕，没有填装自动弹幕记忆之前，通过文件哈希匹配的方式自动添加弹幕（~仅限本地文件~，现已支持网络视频），对于能够哈希匹配关联的文件不再需要手动搜索关联，实现全自动加载弹幕并添加记忆。该功能随记忆型全自动弹幕填装功能一起开启（哈希匹配自动加载准确率较低，如关联到错误的剧集请手动加载正确的剧集）
 10. 通过打开配置项load_more_danmaku可以爬取所有可用弹幕源，获取更多弹幕（注意⚠️：爬取所有可用弹幕源默认关闭，如需开启请阅读[load_more_danmaku配置项说明](#load_more_danmaku)）
@@ -73,6 +73,9 @@
 > 1. scripts目录下放置本插件的文件夹名称必须为uosc_danmaku，否则必须参照uosc控件配置部分[修改uosc控件](#修改uosc控件可选)
 > 2. 记得给bin文件夹下的文件赋予可执行权限
 
+<details open>
+<summary>文件结构</summary>
+
 ```
 ~/.config/mpv/scripts
 └── uosc_danmaku
@@ -109,6 +112,7 @@
     │   └── utils.lua
     └── README.md
 ```
+</details>
 
 ## 基本配置
 
@@ -118,10 +122,11 @@
 
 想要添加uosc控件，需要修改mpv配置文件夹下的 `script-opts`中的 `uosc.conf`文件。如果已经安装了uosc，但是 `script-opts`文件夹下没有 `uosc.conf`文件，可以去[uosc项目地址](https://github.com/tomasklaen/uosc)下载官方的 `uosc.conf`文件，并按照后面的配置步骤进行配置。
 
-由于uosc最近才更新了部分接口和控件代码，导致老旧版本的uosc和新版的uosc配置有所不同。如果是下载的最新git版uosc或者一直保持更新的用户按照[最新版uosc的控件配置步骤](#最新版uosc的控件配置步骤)配置即可。如果不确定自己的uosc版本，或者在使用诸如[MPV_lazy](https://github.com/hooke007/MPV_lazy)等由第三方管理uosc版本的用户，可以使用兼容新版和旧版uosc的[旧版uosc控件配置步骤](#旧版uosc控件配置步骤)
+由于uosc最近才更新了部分接口和控件代码，导致老旧版本的uosc和新版的uosc配置有所不同。如果是下载的最新git版uosc或者一直保持更新的用户按照 `最新版uosc的控件配置步骤` 配置即可。如果不确定自己的uosc版本，或者在使用诸如[MPV_lazy](https://github.com/hooke007/MPV_lazy)等由第三方管理uosc版本的用户，可以按照兼容新版和旧版uosc的 `旧版uosc控件配置步骤` 配置。
 
 <details>
 <summary>最新版uosc的控件配置步骤</summary>
+
 找到 `uosc.conf`文件中的 `controls`配置项，uosc官方默认的配置可能如下：
 
 ```
@@ -190,7 +195,7 @@ show_danmaku_keyboard_key=i
 **带控件的功能**
 
 <details>
-<summary>从弹幕源向当前弹幕添加新弹幕内容</summary>
+<summary>从弹幕源向当前弹幕添加新弹幕内容（从网络url或本地添加弹幕）</summary>
  
 > #### 从弹幕源向当前弹幕添加新弹幕内容（可选）
 
@@ -322,7 +327,7 @@ key script-message immediately_save_danmaku
 ### 弹幕相关
 
 <details>
-<summary>api_server-自定义弹幕API</summary>
+<summary>api_server———自定义弹幕API</summary>
 
 ### api_server
 
@@ -330,7 +335,7 @@ key script-message immediately_save_danmaku
 
 允许自定义弹幕 API 的服务地址
 
-> [!NOTE]
+> **⚠️NOTE！**
 >
 > 请确保自定义服务的 API 与弹弹play 的兼容，已知兼容：[anoraker/abetsy](https://hub.docker.com/repository/docker/anoraker/abetsy)
 
@@ -343,18 +348,21 @@ api_server=https://api.dandanplay.net
 ```
 </details>
 
+---
+
 <details>
-<summary>fallback_server-指定 b 站和爱腾优的弹幕获取的兜底服务器地址</summary>
+<summary>fallback_server———自定义b站和爱腾优的弹幕获取的兜底服务器地址</summary>
 
 ### fallback_server
 
 #### 功能说明
 
-指定 b 站和爱腾优的弹幕获取的兜底服务器地址，主要用于获取非动画弹幕，只有在弹弹play无法解析视频源对应弹幕的情况下才会使用此处设置的服务器进行解析。兜底弹幕服务器可以自托管，具体方法请参考此仓库：https://github.com/lyz05/danmaku
+自定义 b 站和爱腾优的弹幕获取的兜底服务器地址，主要用于获取非动画弹幕，只有在弹弹play无法解析视频源对应弹幕的情况下才会使用此处设置的服务器进行解析。兜底弹幕服务器可以自托管，具体方法请参考此仓库：https://github.com/lyz05/danmaku
 
-> [!NOTE]
+> **⚠️NOTE！**
 >
 > 不设置此选项的情况下默认使用`https://fc.lyz05.cn`作为兜底服务器，除非你自行部署了弹幕服务器，否则不建议自定义此选项。
+
 
 #### 使用方法
 
@@ -365,8 +373,10 @@ fallback_server=https://fc.lyz05.cn
 ```
 </details>
 
+---
+
 <details>
-<summary>tmdb_api_key-设置 tmdb 的 API Key获取非动画条目的中文信息</summary>
+<summary>tmdb_api_key———设置 tmdb 的 API Key获取非动画条目的中文信息</summary>
 
 ### tmdb_api_key
 
@@ -374,7 +384,7 @@ fallback_server=https://fc.lyz05.cn
 
 设置 tmdb 的 API Key，用于获取非动画条目的中文信息(当搜索内容非中文时)。可以在 https://www.themoviedb.org 注册后去个人账号设置界面获取个人的tmdb 的 API Key。
 
-> [!NOTE]
+> **⚠️NOTE！**
 >
 > 不设置此选项的情况下默认使用专为本项目申请的API Key。另外，自定义此选项时还需要对获取到的 API Key 进行 base64 编码。
 
@@ -387,8 +397,10 @@ tmdb_api_key=NmJmYjIxOTZkNzIyN2UyMTIzMGM3Y2YzZjQ4MDNkZGM=
 ```
 </details>
 
+---
+
 <details>
-<summary>load_more_danmaku-获取所有弹幕源加载</summary>
+<summary>load_more_danmaku———开关是否全量弹幕源加载</summary>
 
 ### load_more_danmaku
 
@@ -407,8 +419,10 @@ load_more_danmaku=yes
 ```
 </details>
 
+---
+
 <details>
-<summary>auto_load-全自动弹幕填装</summary>
+<summary>auto_load———开关是否全自动弹幕填装</summary>
 
 ### auto_load
 
@@ -452,8 +466,10 @@ auto_load=yes
 ```
 </details>
 
+---
+
 <details>
-<summary>autoload_local_danmaku-自动加载同目录下的xml格式弹幕文件</summary>
+<summary>autoload_local_danmaku———开关是否自动加载同目录下的xml格式弹幕文件</summary>
 
 ### autoload_local_danmaku
 
@@ -470,8 +486,10 @@ autoload_local_danmaku=yes
 ```
 </details>
 
+---
+
 <details>
-<summary>autoload_for_url-为url视频文件弹幕实现关联记忆和继承</summary>
+<summary>autoload_for_url———开关是否为url视频文件弹幕关联记忆和继承</summary>
 
 ### autoload_for_url
 
@@ -483,7 +501,7 @@ autoload_local_danmaku=yes
 
 另外，开启此选项后还会在网络播放bilibili以及巴哈姆特的视频时自动加载对应视频的弹幕，可配合[Play-With-MPV](https://github.com/LuckyPuppy514/Play-With-MPV)或[ff2mpv](https://github.com/woodruffw/ff2mpv)等网络播放手段使用。（播放巴哈姆特的视频时弹幕自动加载如果失败，请检查[proxy](#proxy)选项配置是否正确）
 
-> [!NOTE]
+> **⚠️NOTE！**
 >
 > 实验性功能，尚不完善
 
@@ -496,12 +514,14 @@ autoload_for_url=yes
 ```
 </details>
 
+---
+
 <details>
-<summary>add_from_source-记录通过 `从弹幕源向当前弹幕添加新弹幕内容`关联过的弹幕源并下次自动加载（已废除）</summary>
+<summary>add_from_source———开关是否记录通过 从弹幕源向当前弹幕添加新弹幕内容 关联过的弹幕源并下次自动加载（已废除）</summary>
 
 ### add_from_source
 
-> [!NOTE]
+> **⚠️NOTE！**
 >
 > 该可选配置项在Release v1.2.0之后已废除。现在通过 `从弹幕源向当前弹幕添加新弹幕内容`功能关联过的弹幕源被记录，并且下次播放同一个视频的时候自动关联并加载所有添加过的弹幕源，这样的行为已经成为了插件的默认行为，不需要再通过 `add_from_source`来开启。在[从源获取弹幕](#从弹幕源向当前弹幕添加新弹幕内容可选)菜单中可以可视化地管理所有添加过的弹幕源。
 
@@ -518,8 +538,10 @@ add_from_source=yes
 ```
 </details>
 
+---
+
 <details>
-<summary>save_danmaku-自动保存弹幕文件（xml格式）至视频同目录</summary>
+<summary>save_danmaku———开关是否自动保存弹幕文件（xml格式）至视频同目录</summary>
 
 ### save_danmaku
 
@@ -527,7 +549,7 @@ add_from_source=yes
 
 当文件关闭时自动保存弹幕文件（xml格式）至视频同目录，保存的弹幕文件名与对应的视频文件名相同。配合[autoload_local_danmaku选项](#autoload_local_danmaku)可以实现弹幕自动保存到本地并且下次播放时自动加载本地保存的弹幕。此功能默认禁用。
 
-> [!NOTE]
+> **⚠️NOTE！**
 >
 > 当开启[autoload_local_danmaku选项](#autoload_local_danmaku)时，会自动加载播放文件同目录下同名的 xml 格式的弹幕文件，优先级高于一切其他自动加载弹幕功能。如果不希望每次播放都加载之前保存的本地弹幕，则请关闭[autoload_local_danmaku选项](#autoload_local_danmaku)；或者在保存完弹幕之后转移弹幕文件至其他路径并关闭 `save_danmaku`选项。
 >
@@ -546,50 +568,10 @@ save_danmaku=yes
 ```
 </details>
 
-<details>
-<summary>user_agent-自定义User Agent</summary>
-
-### user_agent
-
-#### 功能说明
-
-自定义 `curl`发送网络请求时使用的 User Agent，默认值是 `mpv_danmaku/1.0`
-
-#### 使用方法
-
-想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并自定义如下内容（不可为空）：
-
-> [!NOTE]
->
-> User-Agent格式必须符合弹弹play的标准，否则无法成功请求。具体格式要求见[弹弹play官方文档](https://github.com/kaedei/dandanplay-libraryindex/blob/master/api/OpenPlatform.md#5user-agent)
->
-> 若想提高URL播放的哈希匹配成功率，可以将此项设为 `mpv`或浏览器的User-Agent
-
-```
-user_agent=mpv_danmaku/1.0
-```
-</details>
+---
 
 <details>
-<summary>proxy-自定义代理</summary>
-
-### proxy
-
-#### 功能说明
-
-自定义 `curl`发送网络请求时使用的代理，默认禁用
-
-#### 使用方法
-
-想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并自定义如下内容：
-
-```
-proxy=127.0.0.1:7890
-```
-</details>
-
-<details>
-<summary>vf_fps-使用fps视频滤镜提升弹幕平滑度（帧数）</summary>
+<summary>vf_fps———开关是否使用fps视频滤镜提升弹幕平滑度（帧数）</summary>
 
 ### vf_fps
 
@@ -610,8 +592,10 @@ vf_fps=yes
 ```
 </details>
 
+---
+
 <details>
-<summary>fps-自定义fps滤镜参数</summary>
+<summary>fps———自定义fps滤镜参数</summary>
 
 ### fps
 
@@ -630,8 +614,10 @@ fps=60/1.001
 ```
 </details>
 
+---
+
 <details>
-<summary>transparency-自定义弹幕的透明度</summary>
+<summary>transparency———自定义弹幕的透明度</summary>
 
 ### transparency
 
@@ -648,8 +634,10 @@ transparency=48
 ```
 </details>
 
+---
+
 <details>
-<summary>merge_tolerance-指定合并重复弹幕的时间间隔的容差值</summary>
+<summary>merge_tolerance———指定合并重复弹幕的时间间隔的容差值</summary>
 
 ### merge_tolerance
 
@@ -668,8 +656,10 @@ merge_tolerance=1
 ```
 </details>
 
+---
+
 <details>
-<summary>chConvert-中文简繁转换</summary>
+<summary>chConvert———开关是否进行中文简繁转换</summary>
 
 ### chConvert
 
@@ -686,10 +676,58 @@ chConvert=0
 ```
 </details>
 
-### 配置相关
+---
+
+### 插件配置相关
 
 <details>
-<summary>DanmakuFactory_Path-指定DanmakuFactory程序路径</summary>
+<summary>user_agent———自定义User Agent</summary>
+
+### user_agent
+
+#### 功能说明
+
+自定义 `curl`发送网络请求时使用的 User Agent，默认值是 `mpv_danmaku/1.0`
+
+#### 使用方法
+
+想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并自定义如下内容（不可为空）：
+
+> **⚠️NOTE！**
+>
+> User-Agent格式必须符合弹弹play的标准，否则无法成功请求。具体格式要求见[弹弹play官方文档](https://github.com/kaedei/dandanplay-libraryindex/blob/master/api/OpenPlatform.md#5user-agent)
+>
+> 若想提高URL播放的哈希匹配成功率，可以将此项设为 `mpv`或浏览器的User-Agent
+
+```
+user_agent=mpv_danmaku/1.0
+```
+</details>
+
+---
+
+<details>
+<summary>proxy———自定义代理</summary>
+
+### proxy
+
+#### 功能说明
+
+自定义 `curl`发送网络请求时使用的代理，默认禁用
+
+#### 使用方法
+
+想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并自定义如下内容：
+
+```
+proxy=127.0.0.1:7890
+```
+</details>
+
+---
+
+<details>
+<summary>DanmakuFactory_Path———指定DanmakuFactory程序路径</summary>
 
 ### DanmakuFactory_Path
 
@@ -703,7 +741,7 @@ chConvert=0
 
 想要配置此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并添加类似如下内容：
 
-> [!IMPORTANT]
+> **⚠️IMPORTANT！**
 > 不要直接复制这里的配置，这只是一个示例，路径要写成真实存在的路径。此选项可以不配置，脚本会默认选择环境变量或bin文件夹中的可执行文件。
 
 ```
@@ -711,8 +749,10 @@ DanmakuFactory_Path=/path/to/your/DanmakuFactory
 ```
 </details>
 
+---
+
 <details>
-<summary>OpenCC_Path-指定OpenCC程序路径</summary>
+<summary>OpenCC_Path———指定OpenCC程序路径</summary>
 
 ### OpenCC_Path
 
@@ -726,7 +766,7 @@ DanmakuFactory_Path=/path/to/your/DanmakuFactory
 
 想要配置此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并添加类似如下内容：
 
-> [!IMPORTANT]
+> **⚠️IMPORTANT！**
 > 不要直接复制这里的配置，这只是一个示例，路径要写成真实存在的路径。此选项可以不配置，脚本会默认选择环境变量或bin文件夹中的可执行文件。
 
 ```
@@ -734,8 +774,10 @@ OpenCC_Path=/path/to/your/opencc
 ```
 </details>
 
+---
+
 <details>
-<summary>history_path-指定弹幕关联历史记录文件路径</summary>
+<summary>history_path———指定弹幕关联历史记录文件路径</summary>
 
 ### history_path
 
@@ -747,7 +789,7 @@ OpenCC_Path=/path/to/your/opencc
 
 想要配置此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并添加类似如下内容：
 
-> [!IMPORTANT]
+> **⚠️IMPORTANT**
 > 不要直接复制这里的配置，这只是一个示例，路径要写成真实存在的路径。此选项可以不配置，脚本会默认放在mpv配置文件夹的根目录下。
 
 ```
@@ -755,8 +797,10 @@ history_path=/path/to/your/danmaku-history.json
 ```
 </details>
 
+---
+
 <details>
-<summary>message_x-自定义插件相关提示的显示位置（x轴）</summary>
+<summary>message_x———自定义插件相关提示的显示位置（x轴）</summary>
 
 ### message_x
 
@@ -773,8 +817,10 @@ message_x=30
 ```
 </details>
 
+---
+
 <details>
-<summary>message_y-自定义插件相关提示的显示位置（y轴）</summary>
+<summary>message_y———自定义插件相关提示的显示位置（y轴）</summary>
 
 ### message_y
 
@@ -791,8 +837,10 @@ message_y=30
 ```
 </details>
 
+---
+
 <details>
-<summary>title_replace-自定义文件标题解析中的额外替换规则</summary>
+<summary>title_replace———自定义文件标题解析中的额外替换规则</summary>
 
 ### title_replace
 

--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ key script-message immediately_save_danmaku
 
 ## 可配置选项（可选）
 
+本插件可以在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并自定义下例配置可以开启额外功能或自定义功能细节
+
 ### 弹幕相关
 
 <details>

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 >
 > 欲启用此支持mpv最低版本要求：0.39.0
 
+
+
 ## 项目简介
 
 插件具体效果见演示视频：
@@ -23,6 +25,7 @@
 在未安装uosc框架时，调用mpv内部的 `mp.input`进行菜单渲染，具体效果见[此pr](https://github.com/Tony15246/uosc_danmaku/pull/24)
 
 ### 主要功能
+<details open>
 
 1. 从弹弹play或自定义服务的API获取剧集及弹幕数据，并根据用户选择的集数加载弹幕
 2. 通过点击uosc control bar中的弹幕搜索按钮可以显示搜索菜单供用户选择需要的弹幕
@@ -49,6 +52,9 @@
 另外本插件也使用了DanmakuFactory弹幕格式转换工具。在Windows平台和Linux平台上本插件均调用作者自己编译构建的可执行文件。如果本项目仓库中bin文件夹下提供的可执行文件无法正确运行，请前往[DanmakuFactory项目地址](https://github.com/hihkm/DanmakuFactory)，按照其教程选择或编译兼容自己环境的可执行文件。
 
 字体简繁转换基于OpenCC简繁转换工具。在Windows平台上本插件调用OpenCC官方编译的x86_64版本，在Linux平台上本插件调用基于作者自己Linux系统编译的二进制文件。如果本项目仓库中bin文件夹下提供的可执行文件无法正确运行，请前往[OpenCC项目地址](https://github.com/BYVoid/OpenCC)，按照其教程选择或编译兼容自己环境的可执行文件。
+</details>
+
+
 
 ## 安装
 
@@ -113,6 +119,8 @@
     └── README.md
 ```
 </details>
+
+
 
 ## 基本配置
 
@@ -186,9 +194,11 @@ open_search_danmaku_menu_key=Ctrl+i
 show_danmaku_keyboard_key=i
 ```
 
+
+
 ## 拓展功能（可选）
 
-本插件针对弹幕有丰厚的拓展功能
+本插件针对弹幕有全方面的拓展功能
 
 ---
 
@@ -232,6 +242,7 @@ C:\Users\Tony\Downloads\example.xml
 现已更新增强了此菜单。现在在该菜单内可以可视化地控制所有弹幕源，删除或者屏蔽任何不想要的弹幕源。对于自己手动添加的弹幕源，可以进行移除。对于来自弹弹play的弹幕源，无法进行移除，但是可以进行屏蔽，将不会再从屏蔽过的弹幕源获取弹幕。当然，也可以解除对来自弹弹play的弹幕源的屏蔽。另外需要注意在菜单内对于弹幕源的可视化操作都需要下次打开视频，或者重新用弹幕搜索功能加载一次弹幕才会生效。
 </details>
 
+
 <details>
 <summary>弹幕源延迟设置</summary>
 
@@ -248,6 +259,7 @@ key script-message open_source_delay_menu
 ```
 </details>
 
+
 <details>
 <summary> 实时修改弹幕样式</summary>
 
@@ -261,6 +273,7 @@ key script-message open_source_delay_menu
 key script-message open_setup_danmaku_menu
 ```
 </details>
+
 
 <details>
 <summary> 弹幕设置总菜单</summary>
@@ -294,19 +307,6 @@ key script-message danmaku-delay <seconds>
 > 当前弹幕延迟的值可以从 `user-data/uosc_danmaku/danmaku-delay`属性中获取到，具体用法可以参考[此issue](https://github.com/Tony15246/uosc_danmaku/issues/77)
 </details>
 
-<details>
-<summary>清空当前视频关联的弹幕源</summary>
-
-> #### 清空当前视频关联的弹幕源（可选）
-
-可以清空当前视频中，用户通过[从源获取弹幕](#从弹幕源向当前弹幕添加新弹幕内容可选)菜单手动添加的所有弹幕源（注意该功能不会删除来源于弹幕服务器的弹幕，此类弹幕只能屏蔽或者手动重新匹配新弹幕库）。清空过弹幕源之后，下次播放该视频，就不会再加载之前手动添加过的弹幕源，可以重新添加弹幕源。
-
-想要通过快捷键使用此功能，请添加类似下面的配置到 `input.conf`中。从源添加弹幕功能对应的脚本消息为 `clear-source`。
-
-```
-key script-message clear-source
-```
-</details>
 
 <details>
 <summary>保存当前视频弹幕</summary>
@@ -322,11 +322,364 @@ key script-message immediately_save_danmaku
 ```
 </details>
 
+
+<details>
+<summary>清空当前视频关联的弹幕源</summary>
+
+> #### 清空当前视频关联的弹幕源（可选）
+
+可以清空当前视频中，用户通过[从源获取弹幕](#从弹幕源向当前弹幕添加新弹幕内容可选)菜单手动添加的所有弹幕源（注意该功能不会删除来源于弹幕服务器的弹幕，此类弹幕只能屏蔽或者手动重新匹配新弹幕库）。清空过弹幕源之后，下次播放该视频，就不会再加载之前手动添加过的弹幕源，可以重新添加弹幕源。
+
+想要通过快捷键使用此功能，请添加类似下面的配置到 `input.conf`中。从源添加弹幕功能对应的脚本消息为 `clear-source`。
+
+```
+key script-message clear-source
+```
+</details>
+
+---
+
 ## 可配置选项（可选）
 
-本插件可以在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并自定义下例配置可以开启额外功能或自定义功能细节
+本插件可以在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件自定义下例配置开启额外功能或自定义功能细节
 
-### 弹幕相关
+### 弹幕加载相关
+
+<!--  下列是弹幕加载相关  -->
+
+<details>
+<summary>
+load_more_danmaku
+
+> 开关全量弹幕源加载
+</summary>
+
+### load_more_danmaku
+
+#### 功能说明
+
+由于弹弹Play默认对于弹幕较多的番剧加载并且整合弹幕的上限大约每集7000条，而这7000条弹幕也不是均匀分配，例如有时弹幕基本只来自于哔哩哔哩，有时弹幕又只来自于巴哈姆特。这样的话弹幕观看体验就和直接在哔哩哔哩或者巴哈姆特观看没有区别了，失去了弹弹Play整合全平台弹幕的优势。
+
+因此，本人添加了配置选项 `load_more_danmaku`，用来将从弹弹Play获取弹幕的逻辑更改为逐一搜索所有弹幕源下的全部弹幕，并由本脚本整合加载。开启此选项可以获取到所有可用弹幕源下的所有弹幕。但是对于一些热门番剧来说，弹幕数量可能破万，如果接受不了屏幕上弹幕太多，请不要开启此选项。（嘛，不过本人看视频从来只会觉得弹幕多多益善）
+
+#### 使用方法
+
+想要开启此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并添加如下内容：
+
+```
+load_more_danmaku=yes
+```
+</details>
+
+---
+
+<details>
+<summary>
+auto_load
+
+> 开关全自动弹幕填装
+</summary>
+
+### auto_load
+
+#### 功能说明
+
+该选项控制是否开启全自动弹幕填装功能。该功能会在为某个文件夹下的某一集番剧加载过一次弹幕后，把加载过的弹幕会自动关联到该集。之后每次重新播放该文件就会自动加载对应的弹幕，同时该文件对应的文件夹下的所有其他集数的文件都会在播放时自动加载弹幕。
+
+举个例子，比如说有一个文件夹结构如下
+
+```
+败犬女主太多了
+├── KitaujiSub_Make_Heroine_ga_Oosugiru!_01WebRipHEVC_AACCHS_JP.mp4
+├── KitaujiSub_Make_Heroine_ga_Oosugiru!_02WebRipHEVC_AACCHS_JP.mp4
+├── KitaujiSub_Make_Heroine_ga_Oosugiru!_03WebRipHEVC_AACCHS_JP.mp4
+├── KitaujiSub_Make_Heroine_ga_Oosugiru!_04WebRipHEVC_AACCHS_JP.mp4
+├── KitaujiSub_Make_Heroine_ga_Oosugiru!_05WebRipHEVC_AACCHS_JP.mp4
+├── KitaujiSub_Make_Heroine_ga_Oosugiru!_06WebRipHEVC_AACCHS_JP.mp4
+├── KitaujiSub_Make_Heroine_ga_Oosugiru!_07v2WebRipHEVC_AACCHS_JP.mp4
+└── KitaujiSub_Make_Heroine_ga_Oosugiru!_08WebRipHEVC_AACCHS_JP.mp4
+```
+
+只要在播放第一集 `KitaujiSub_Make_Heroine_ga_Oosugiru!_01WebRipHEVC_AACCHS_JP.mp4`的时候手动搜索并且加载过一次弹幕，那么打开第二集时就会直接自动加载第二集的弹幕，打开第三集时就会直接加载第三集的弹幕，以此类推，不用再手动搜索
+
+#### 使用方法
+
+想要开启此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并添加如下内容：
+
+```
+auto_load=yes
+```
+
+注意⚠️： 一个文件夹下有且仅有一同部番剧的若干视频文件才会生效。下面这种情况下，如果手动搜索并且加载过一次《少女歌剧》第一集的弹幕，《哭泣少女乐队》第二集必须重新手动识别，但这样会破坏《少女歌剧》的弹幕记录
+
+```
+少女歌剧
+├── 少女歌剧1.mp4
+├── 少女歌剧2.mp4
+├── 少女歌剧3.mp4
+├── 少女歌剧4.mp4
+└── 哭泣少女乐队2.mp4
+```
+</details>
+
+---
+
+<details>
+<summary>
+autoload_for_url
+
+> 开关url播放场景自动加载弹幕与关联继承
+</summary>
+
+### autoload_for_url
+
+#### 功能说明
+
+开启此选项后，会为可能支持的 url 视频文件实现弹幕关联记忆和继承，配合播放列表食用效果最佳。目前兼容在使用[embyToLocalPlayer](https://github.com/kjtsune/embyToLocalPlayer)、[mpv-torrserver](https://github.com/dyphire/mpv-config/blob/master/scripts/mpv-torrserver.lua)、[tsukimi](https://github.com/tsukinaha/tsukimi)等场景时进行弹幕关联记忆和继承。
+
+目前的具体支持情况和实现效果可以参考[此pr](https://github.com/Tony15246/uosc_danmaku/pull/16)
+
+另外，开启此选项后还会在网络播放bilibili以及巴哈姆特的视频时自动加载对应视频的弹幕，可配合[Play-With-MPV](https://github.com/LuckyPuppy514/Play-With-MPV)或[ff2mpv](https://github.com/woodruffw/ff2mpv)等网络播放手段使用。（播放巴哈姆特的视频时弹幕自动加载如果失败，请检查[proxy](#proxy)选项配置是否正确）
+
+> **⚠️NOTE！**
+>
+> 实验性功能，尚不完善
+
+#### 使用方法
+
+想要开启此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并添加如下内容：
+
+```
+autoload_for_url=yes
+```
+</details>
+
+---
+
+<details>
+<summary>
+autoload_local_danmaku
+
+> 开关自动加载同目录下的xml格式弹幕文件
+</summary>
+
+### autoload_local_danmaku
+
+#### 功能说明
+
+自动加载播放文件同目录下同名的 xml 格式的弹幕文件
+
+#### 使用方法
+
+想要开启此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并添加如下内容：
+
+```
+autoload_local_danmaku=yes
+```
+</details>
+
+---
+
+<details>
+<summary>
+save_danmaku
+
+> 开关自动保存弹幕文件（xml格式）至视频同目录
+</summary>
+
+### save_danmaku
+
+#### 功能说明
+
+当文件关闭时自动保存弹幕文件（xml格式）至视频同目录，保存的弹幕文件名与对应的视频文件名相同。配合[autoload_local_danmaku选项](#autoload_local_danmaku)可以实现弹幕自动保存到本地并且下次播放时自动加载本地保存的弹幕。此功能默认禁用。
+
+> **⚠️NOTE！**
+>
+> 当开启[autoload_local_danmaku选项](#autoload_local_danmaku)时，会自动加载播放文件同目录下同名的 xml 格式的弹幕文件，优先级高于一切其他自动加载弹幕功能。如果不希望每次播放都加载之前保存的本地弹幕，则请关闭[autoload_local_danmaku选项](#autoload_local_danmaku)；或者在保存完弹幕之后转移弹幕文件至其他路径并关闭 `save_danmaku`选项。
+>
+> `save_danmaku`选项的打开和关闭可以运行时实时更新。在 `input.conf`中添加如下内容，可通过快捷键实时控制 `save_danmaku`选项的打开和关闭
+>
+> ```
+> key cycle-values script-opts uosc_danmaku-save_danmaku=yes uosc_danmaku-save_danmaku=no
+> ```
+
+#### 使用方法
+
+想要启用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并指定如下内容：
+
+```
+save_danmaku=yes
+```
+</details>
+
+---
+
+<details>
+<summary>
+
+~~add_from_source~~
+
+> ~~开关记录通过 从弹幕源向当前弹幕添加新弹幕内容 关联过的弹幕源并自动加载（已废除）~~
+</summary>
+
+### add_from_source
+
+> **⚠️NOTE！**
+>
+> 该可选配置项在Release v1.2.0之后已废除。现在通过 `从弹幕源向当前弹幕添加新弹幕内容`功能关联过的弹幕源被记录，并且下次播放同一个视频的时候自动关联并加载所有添加过的弹幕源，这样的行为已经成为了插件的默认行为，不需要再通过 `add_from_source`来开启。在[从源获取弹幕](#从弹幕源向当前弹幕添加新弹幕内容可选)菜单中可以可视化地管理所有添加过的弹幕源。
+
+#### 功能说明
+
+开启此选项后，通过 `从弹幕源向当前弹幕添加新弹幕内容`功能关联过的弹幕源会被记录，并且下次播放同一个视频的时候会自动关联并加载添加过的弹幕源。
+
+#### 使用方法
+
+想要开启此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并添加如下内容：
+
+```
+add_from_source=yes
+```
+</details>
+
+---
+
+### 弹幕显示相关
+
+(如果需要更细节的弹幕样式修改请看[自定义弹幕样式](#DanmakuFactory相关配置自定义弹幕样式相关配置))
+
+<!--  下列是弹幕显示相关  -->
+
+<details>
+<summary>
+transparency
+
+> 自定义弹幕的透明度
+</summary>
+
+### transparency
+
+#### 功能说明
+
+自定义弹幕的透明度，0（不透明）到255（完全透明）。默认值：48
+
+#### 使用方法
+
+想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并自定义如下内容：
+
+```
+transparency=48
+```
+</details>
+
+---
+
+<details>
+<summary>
+chConvert
+
+> 开关中文简繁转换
+</summary>
+
+### chConvert
+
+#### 功能说明
+
+中文简繁转换。0-不转换，1-转换为简体，2-转换为繁体。默认值: 0，不转换简繁字体，按照弹幕源原本字体显示
+
+#### 使用方法
+
+想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并自定义如下内容：
+
+```
+chConvert=0
+```
+</details>
+
+---
+
+<details>
+<summary>
+merge_tolerance
+
+> 开关合并重复弹幕并设置容差值
+</summary>
+
+### merge_tolerance
+
+#### 功能说明
+
+指定合并重复弹幕的时间间隔的容差值，单位为秒。默认值: -1，表示禁用
+
+当值设为0时会合并同一时间相同内容的弹幕，值大于0时会合并指定秒数误差内的相同内容的弹幕
+
+#### 使用方法
+
+想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并自定义如下内容：
+
+```
+merge_tolerance=1
+```
+</details>
+
+---
+
+<details>
+<summary>
+vf_fps
+
+> 开关使用fps视频滤镜提升弹幕平滑度（帧数）
+</summary>
+
+### vf_fps
+
+#### 功能说明
+
+指定是否使用 fps 视频滤镜 `@danmaku:fps=fps=60/1.001`，可大幅提升弹幕平滑度。默认禁用
+
+注意该视频滤镜的性能开销较大，需在确保设备性能足够的前提下开启
+
+启用选项后仅在视频帧率小于 60 及显示器刷新率大于等于 60 时生效
+
+#### 使用方法
+
+想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并指定如下内容：
+
+```
+vf_fps=yes
+```
+</details>
+
+---
+
+<details>
+<summary>
+fps
+
+> 自定义fps滤镜参数适配不同显示器刷新率
+</summary>
+
+### fps
+
+#### 功能说明
+
+指定要使用的 fps 滤镜参数，例如如果设置fps为 `60/1.001`，则实际生效的视频滤镜参数为 `@danmaku:fps=fps=60/1.001`
+
+使用这个选项，可以根据自己显示器的刷新率调整要使用的视频滤镜参数
+
+#### 使用方法
+
+想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并指定如下内容：
+
+```
+fps=60/1.001
+```
+</details>
+
+---
+
+### 弹幕解析服务相关
+
+<!--  下列是弹幕解析服务相关  -->
 
 <details>
 <summary>
@@ -389,7 +742,7 @@ fallback_server=https://fc.lyz05.cn
 <summary>
 tmdb_api_key
 
-> 设置 tmdb 的 API Key获取非动画条目的中文信息
+> 自定义 tmdb 的 API Key获取非动画条目的中文信息
 </summary>
 
 ### tmdb_api_key
@@ -413,336 +766,13 @@ tmdb_api_key=NmJmYjIxOTZkNzIyN2UyMTIzMGM3Y2YzZjQ4MDNkZGM=
 
 ---
 
-<details>
-<summary>
-load_more_danmaku
-
-> 开关是否全量弹幕源加载
-</summary>
-
-### load_more_danmaku
-
-#### 功能说明
-
-由于弹弹Play默认对于弹幕较多的番剧加载并且整合弹幕的上限大约每集7000条，而这7000条弹幕也不是均匀分配，例如有时弹幕基本只来自于哔哩哔哩，有时弹幕又只来自于巴哈姆特。这样的话弹幕观看体验就和直接在哔哩哔哩或者巴哈姆特观看没有区别了，失去了弹弹Play整合全平台弹幕的优势。
-
-因此，本人添加了配置选项 `load_more_danmaku`，用来将从弹弹Play获取弹幕的逻辑更改为逐一搜索所有弹幕源下的全部弹幕，并由本脚本整合加载。开启此选项可以获取到所有可用弹幕源下的所有弹幕。但是对于一些热门番剧来说，弹幕数量可能破万，如果接受不了屏幕上弹幕太多，请不要开启此选项。（嘛，不过本人看视频从来只会觉得弹幕多多益善）
-
-#### 使用方法
-
-想要开启此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并添加如下内容：
-
-```
-load_more_danmaku=yes
-```
-</details>
-
----
-
-<details>
-<summary>
-auto_load
-
-> 开关是否全自动弹幕填装
-</summary>
-
-### auto_load
-
-#### 功能说明
-
-该选项控制是否开启全自动弹幕填装功能。该功能会在为某个文件夹下的某一集番剧加载过一次弹幕后，把加载过的弹幕会自动关联到该集。之后每次重新播放该文件就会自动加载对应的弹幕，同时该文件对应的文件夹下的所有其他集数的文件都会在播放时自动加载弹幕。
-
-举个例子，比如说有一个文件夹结构如下
-
-```
-败犬女主太多了
-├── KitaujiSub_Make_Heroine_ga_Oosugiru!_01WebRipHEVC_AACCHS_JP.mp4
-├── KitaujiSub_Make_Heroine_ga_Oosugiru!_02WebRipHEVC_AACCHS_JP.mp4
-├── KitaujiSub_Make_Heroine_ga_Oosugiru!_03WebRipHEVC_AACCHS_JP.mp4
-├── KitaujiSub_Make_Heroine_ga_Oosugiru!_04WebRipHEVC_AACCHS_JP.mp4
-├── KitaujiSub_Make_Heroine_ga_Oosugiru!_05WebRipHEVC_AACCHS_JP.mp4
-├── KitaujiSub_Make_Heroine_ga_Oosugiru!_06WebRipHEVC_AACCHS_JP.mp4
-├── KitaujiSub_Make_Heroine_ga_Oosugiru!_07v2WebRipHEVC_AACCHS_JP.mp4
-└── KitaujiSub_Make_Heroine_ga_Oosugiru!_08WebRipHEVC_AACCHS_JP.mp4
-```
-
-只要在播放第一集 `KitaujiSub_Make_Heroine_ga_Oosugiru!_01WebRipHEVC_AACCHS_JP.mp4`的时候手动搜索并且加载过一次弹幕，那么打开第二集时就会直接自动加载第二集的弹幕，打开第三集时就会直接加载第三集的弹幕，以此类推，不用再手动搜索
-
-#### 使用方法
-
-想要开启此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并添加如下内容：
-
-```
-auto_load=yes
-```
-
-注意⚠️： 一个文件夹下有且仅有一同部番剧的若干视频文件才会生效。下面这种情况下，如果手动搜索并且加载过一次《少女歌剧》第一集的弹幕，《哭泣少女乐队》第二集必须重新手动识别，但这样会破坏《少女歌剧》的弹幕记录
-
-```
-少女歌剧
-├── 少女歌剧1.mp4
-├── 少女歌剧2.mp4
-├── 少女歌剧3.mp4
-├── 少女歌剧4.mp4
-└── 哭泣少女乐队2.mp4
-```
-</details>
-
----
-
-<details>
-<summary>
-autoload_local_danmaku
-
-> 开关是否自动加载同目录下的xml格式弹幕文件
-</summary>
-
-### autoload_local_danmaku
-
-#### 功能说明
-
-自动加载播放文件同目录下同名的 xml 格式的弹幕文件
-
-#### 使用方法
-
-想要开启此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并添加如下内容：
-
-```
-autoload_local_danmaku=yes
-```
-</details>
-
----
-
-<details>
-<summary>
-autoload_for_url
-
-> 开关是否为url视频文件弹幕关联记忆和继承
-</summary>
-
-### autoload_for_url
-
-#### 功能说明
-
-开启此选项后，会为可能支持的 url 视频文件实现弹幕关联记忆和继承，配合播放列表食用效果最佳。目前兼容在使用[embyToLocalPlayer](https://github.com/kjtsune/embyToLocalPlayer)、[mpv-torrserver](https://github.com/dyphire/mpv-config/blob/master/scripts/mpv-torrserver.lua)、[tsukimi](https://github.com/tsukinaha/tsukimi)等场景时进行弹幕关联记忆和继承。
-
-目前的具体支持情况和实现效果可以参考[此pr](https://github.com/Tony15246/uosc_danmaku/pull/16)
-
-另外，开启此选项后还会在网络播放bilibili以及巴哈姆特的视频时自动加载对应视频的弹幕，可配合[Play-With-MPV](https://github.com/LuckyPuppy514/Play-With-MPV)或[ff2mpv](https://github.com/woodruffw/ff2mpv)等网络播放手段使用。（播放巴哈姆特的视频时弹幕自动加载如果失败，请检查[proxy](#proxy)选项配置是否正确）
-
-> **⚠️NOTE！**
->
-> 实验性功能，尚不完善
-
-#### 使用方法
-
-想要开启此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并添加如下内容：
-
-```
-autoload_for_url=yes
-```
-</details>
-
----
-
-<details>
-<summary>
-add_from_source
-
-> 开关是否记录通过 从弹幕源向当前弹幕添加新弹幕内容 关联过的弹幕源并下次自动加载（已废除）
-</summary>
-
-### add_from_source
-
-> **⚠️NOTE！**
->
-> 该可选配置项在Release v1.2.0之后已废除。现在通过 `从弹幕源向当前弹幕添加新弹幕内容`功能关联过的弹幕源被记录，并且下次播放同一个视频的时候自动关联并加载所有添加过的弹幕源，这样的行为已经成为了插件的默认行为，不需要再通过 `add_from_source`来开启。在[从源获取弹幕](#从弹幕源向当前弹幕添加新弹幕内容可选)菜单中可以可视化地管理所有添加过的弹幕源。
-
-#### 功能说明
-
-开启此选项后，通过 `从弹幕源向当前弹幕添加新弹幕内容`功能关联过的弹幕源会被记录，并且下次播放同一个视频的时候会自动关联并加载添加过的弹幕源。
-
-#### 使用方法
-
-想要开启此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并添加如下内容：
-
-```
-add_from_source=yes
-```
-</details>
-
----
-
-<details>
-<summary>
-save_danmaku
-
-> 开关是否自动保存弹幕文件（xml格式）至视频同目录
-</summary>
-
-### save_danmaku
-
-#### 功能说明
-
-当文件关闭时自动保存弹幕文件（xml格式）至视频同目录，保存的弹幕文件名与对应的视频文件名相同。配合[autoload_local_danmaku选项](#autoload_local_danmaku)可以实现弹幕自动保存到本地并且下次播放时自动加载本地保存的弹幕。此功能默认禁用。
-
-> **⚠️NOTE！**
->
-> 当开启[autoload_local_danmaku选项](#autoload_local_danmaku)时，会自动加载播放文件同目录下同名的 xml 格式的弹幕文件，优先级高于一切其他自动加载弹幕功能。如果不希望每次播放都加载之前保存的本地弹幕，则请关闭[autoload_local_danmaku选项](#autoload_local_danmaku)；或者在保存完弹幕之后转移弹幕文件至其他路径并关闭 `save_danmaku`选项。
->
-> `save_danmaku`选项的打开和关闭可以运行时实时更新。在 `input.conf`中添加如下内容，可通过快捷键实时控制 `save_danmaku`选项的打开和关闭
->
-> ```
-> key cycle-values script-opts uosc_danmaku-save_danmaku=yes uosc_danmaku-save_danmaku=no
-> ```
-
-#### 使用方法
-
-想要启用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并指定如下内容：
-
-```
-save_danmaku=yes
-```
-</details>
-
----
-
-<details>
-<summary>
-vf_fps
-
-> 开关是否使用fps视频滤镜提升弹幕平滑度（帧数）
-</summary>
-
-### vf_fps
-
-#### 功能说明
-
-指定是否使用 fps 视频滤镜 `@danmaku:fps=fps=60/1.001`，可大幅提升弹幕平滑度。默认禁用
-
-注意该视频滤镜的性能开销较大，需在确保设备性能足够的前提下开启
-
-启用选项后仅在视频帧率小于 60 及显示器刷新率大于等于 60 时生效
-
-#### 使用方法
-
-想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并指定如下内容：
-
-```
-vf_fps=yes
-```
-</details>
-
----
-
-<details>
-<summary>
-fps
-
-> 自定义fps滤镜参数
-</summary>
-
-### fps
-
-#### 功能说明
-
-指定要使用的 fps 滤镜参数，例如如果设置fps为 `60/1.001`，则实际生效的视频滤镜参数为 `@danmaku:fps=fps=60/1.001`
-
-使用这个选项，可以根据自己显示器的刷新率调整要使用的视频滤镜参数
-
-#### 使用方法
-
-想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并指定如下内容：
-
-```
-fps=60/1.001
-```
-</details>
-
----
-
-<details>
-<summary>
-transparency
-
-> 自定义弹幕的透明度
-</summary>
-
-### transparency
-
-#### 功能说明
-
-自定义弹幕的透明度，0（不透明）到255（完全透明）。默认值：48
-
-#### 使用方法
-
-想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并自定义如下内容：
-
-```
-transparency=48
-```
-</details>
-
----
-
-<details>
-<summary>
-merge_tolerance
-
-> 指定合并重复弹幕的时间间隔的容差值
-</summary>
-
-### merge_tolerance
-
-#### 功能说明
-
-指定合并重复弹幕的时间间隔的容差值，单位为秒。默认值: -1，表示禁用
-
-当值设为0时会合并同一时间相同内容的弹幕，值大于0时会合并指定秒数误差内的相同内容的弹幕
-
-#### 使用方法
-
-想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并自定义如下内容：
-
-```
-merge_tolerance=1
-```
-</details>
-
----
-
-<details>
-<summary>
-chConvert
-
-> 开关是否进行中文简繁转换
-</summary>
-
-### chConvert
-
-#### 功能说明
-
-中文简繁转换。0-不转换，1-转换为简体，2-转换为繁体。默认值: 0，不转换简繁字体，按照弹幕源原本字体显示
-
-#### 使用方法
-
-想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并自定义如下内容：
-
-```
-chConvert=0
-```
-</details>
-
----
-
 ### 插件配置相关
 
 <details>
 <summary>
 user_agent
 
-> 自定义User Agent
+> 自定义请求时的User Agent
 </summary>
 
 ### user_agent
@@ -772,7 +802,7 @@ user_agent=mpv_danmaku/1.0
 <summary>
 proxy
 
-> 自定义代理
+> 自定义请求时的代理
 </summary>
 
 ### proxy
@@ -787,6 +817,76 @@ proxy
 
 ```
 proxy=127.0.0.1:7890
+```
+</details>
+
+---
+
+<details>
+<summary>
+message_x
+
+> 自定义插件相关提示的显示位置（x轴）
+</summary>
+
+### message_x
+
+#### 功能说明
+
+自定义插件相关提示的显示位置，距离屏幕左上角的x轴的距离
+
+#### 使用方法
+
+想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并自定义如下内容：
+
+```
+message_x=30
+```
+</details>
+
+---
+
+<details>
+<summary>
+message_y
+
+> 自定义插件相关提示的显示位置（y轴）
+</summary>
+
+### message_y
+
+#### 功能说明
+
+自定义插件相关提示的显示位置，距离屏幕左上角的y轴的距离
+
+#### 使用方法
+
+想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并自定义如下内容：
+
+```
+message_y=30
+```
+</details>
+
+---
+
+<details>
+<summary>
+title_replace
+
+> 自定义文件标题解析中的额外替换规则
+</summary>
+
+### title_replace
+
+自定义标题解析中的额外替换规则，内容格式为 JSON 字符串，替换模式为 lua 的 string.gsub 函数
+
+注意⚠️：由于 mpv 的 lua 版本限制，自定义规则只支持形如 %n 的捕获组写法，即示例用法，不支持直接替换字符的写法
+
+用法示例：
+
+```
+title_replace=[{"rules":[{ "^〔(.-)〕": "%1"},{ "^.*《(.-)》": "%1" }]}]
 ```
 </details>
 
@@ -877,74 +977,6 @@ history_path=/path/to/your/danmaku-history.json
 
 ---
 
-<details>
-<summary>
-message_x
-
-> 自定义插件相关提示的显示位置（x轴）
-</summary>
-
-### message_x
-
-#### 功能说明
-
-自定义插件相关提示的显示位置，距离屏幕左上角的x轴的距离
-
-#### 使用方法
-
-想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并自定义如下内容：
-
-```
-message_x=30
-```
-</details>
-
----
-
-<details>
-<summary>
-message_y
-
-> 自定义插件相关提示的显示位置（y轴）
-</summary>
-
-### message_y
-
-#### 功能说明
-
-自定义插件相关提示的显示位置，距离屏幕左上角的y轴的距离
-
-#### 使用方法
-
-想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并自定义如下内容：
-
-```
-message_y=30
-```
-</details>
-
----
-
-<details>
-<summary>
-title_replace
-
-> 自定义文件标题解析中的额外替换规则
-</summary>
-
-### title_replace
-
-自定义标题解析中的额外替换规则，内容格式为 JSON 字符串，替换模式为 lua 的 string.gsub 函数
-
-注意⚠️：由于 mpv 的 lua 版本限制，自定义规则只支持形如 %n 的捕获组写法，即示例用法，不支持直接替换字符的写法
-
-用法示例：
-
-```
-title_replace=[{"rules":[{ "^〔(.-)〕": "%1"},{ "^.*《(.-)》": "%1" }]}]
-```
-</details>
-
 ### DanmakuFactory相关配置（自定义弹幕样式相关配置）
 
 默认配置如下，可根据需求更改并自定义弹幕样式
@@ -977,6 +1009,8 @@ blockmode=REPEAT
 blacklist_path=
 ```
 
+
+
 ## 常见问题
 
 ### 我在Windows平台上使用此插件，总是会显示“未找到弹幕文件”/搜索弹幕总是无结果/弹幕无法加载
@@ -988,6 +1022,8 @@ blacklist_path=
 ### 简繁转换功能无法生效
 
 检查mpv及其本插件是否安装在了含中文字符的文件夹路径下。简繁转换功能所依赖的OpenCC第三方工具在非英文路径名下无法正常工作。想了解更多可以参考[此discussion](https://github.com/Tony15246/uosc_danmaku/discussions/92)
+
+
 
 ## 特别感谢
 

--- a/README.md
+++ b/README.md
@@ -76,11 +76,16 @@
 ```
 ~/.config/mpv/scripts
 └── uosc_danmaku
-    ├── api.lua
+    ├── apis
+    │   ├── dandanplay.lua
+    │   └── extra.lua
     ├── bin
     │   ├── dandanplay
     │   │   ├── dandanplay
     │   │   └── dandanplay.exe
+    │   ├── DanmakuFactory
+    │   │   ├── DanmakuFactory
+    │   │   └── DanmakuFactory.exe
     │   ├── OpenCC_Linux
     │   │   └── opencc
     │   └── OpenCC_Windows
@@ -94,10 +99,15 @@
     │       └── TSPhrases.ocd2
     ├── LICENSE
     ├── main.lua
-    ├── md5.lua
-    ├── options.lua
-    ├── README.md
-    └── render.lua
+    ├── modules
+    │   ├── base64.lua
+    │   ├── guess.lua
+    │   ├── md5.lua
+    │   ├── menu.lua
+    │   ├── options.lua
+    │   ├── render.lua
+    │   └── utils.lua
+    └── README.md
 ```
 
 ## 基本配置
@@ -270,7 +280,7 @@ key script-message open_add_total_menu
 
 > #### 设置弹幕延迟（可选）
 
-可以通过快捷键绑定以下命令来调整弹幕延迟，单位：秒。可以为负数
+可以通过快捷键绑定以下命令来调整弹幕延迟，单位：秒。秒数的含义为在当前弹幕延迟的基础上叠加新设置的延迟秒数进行调整，可以设置为负数。另外，设置为0时为特殊情况，会将弹幕延迟重置为0，回到初始状态。
 
 ```
 key script-message danmaku-delay <seconds>
@@ -330,6 +340,50 @@ key script-message immediately_save_danmaku
 
 ```
 api_server=https://api.dandanplay.net
+```
+</details>
+
+<details>
+<summary>fallback_server-指定 b 站和爱腾优的弹幕获取的兜底服务器地址</summary>
+
+### fallback_server
+
+#### 功能说明
+
+指定 b 站和爱腾优的弹幕获取的兜底服务器地址，主要用于获取非动画弹幕，只有在弹弹play无法解析视频源对应弹幕的情况下才会使用此处设置的服务器进行解析。兜底弹幕服务器可以自托管，具体方法请参考此仓库：https://github.com/lyz05/danmaku
+
+> [!NOTE]
+>
+> 不设置此选项的情况下默认使用`https://fc.lyz05.cn`作为兜底服务器，除非你自行部署了弹幕服务器，否则不建议自定义此选项。
+
+#### 使用方法
+
+想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并自定义如下内容：
+
+```
+fallback_server=https://fc.lyz05.cn
+```
+</details>
+
+<details>
+<summary>tmdb_api_key-设置 tmdb 的 API Key获取非动画条目的中文信息</summary>
+
+### tmdb_api_key
+
+#### 功能说明
+
+设置 tmdb 的 API Key，用于获取非动画条目的中文信息(当搜索内容非中文时)。可以在 https://www.themoviedb.org 注册后去个人账号设置界面获取个人的tmdb 的 API Key。
+
+> [!NOTE]
+>
+> 不设置此选项的情况下默认使用专为本项目申请的API Key。另外，自定义此选项时还需要对获取到的 API Key 进行 base64 编码。
+
+#### 使用方法
+
+想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并自定义如下内容：
+
+```
+tmdb_api_key=NmJmYjIxOTZkNzIyN2UyMTIzMGM3Y2YzZjQ4MDNkZGM=
 ```
 </details>
 


### PR DESCRIPTION
第一次给项目提pr，不敢乱动只把大量功能收纳了()，也排了排序小分类了一下，感觉不是自己的项目不知道哪些要保留展现💦 但是主要功能说明那边我要明确说真的很需要精简，字太多了用户反而会跳过不看（
然后也是一边学一边写了（
GitHub的Markdown不支持`<details>`中嵌套使用`[!NOTE]`很烦只能模拟效果了，还有Markdown围栏只能创建代码围栏不能创建普通区域围栏很烦，想划分区域显示文本做不到的感觉，只能用了很多---分割线

现在拓展功能被划分为了
`带控件的功能`
`仅快捷键的功能`
可配置选项划分为了
`弹幕加载相关`
`弹幕显示相关`
`弹幕解析服务相关`
`插件配置相关`

非必要功能和配置项都被`<details></details>`收纳`<summary></summary>`展示说明 并且用`---`分割线与其他的分割提升可读性

一个功能的结构是
~~~
---

<details>
<summary>
fps

> 自定义fps滤镜参数适配不同显示器刷新率
</summary>

### fps

#### 功能说明

指定要使用的 fps 滤镜参数，例如如果设置fps为 `60/1.001`，则实际生效的视频滤镜参数为 `@danmaku:fps=fps=60/1.001`

使用这个选项，可以根据自己显示器的刷新率调整要使用的视频滤镜参数

#### 使用方法

想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并指定如下内容：

```
fps=60/1.001
```
</details>

---
~~~