### PR TITLE
fix: danmaku overlapping in right part of screen #291

### DIFF
--- a/modules/parse.lua
+++ b/modules/parse.lua
@@ -378,8 +378,6 @@ end
 -- 滚动弹幕 Y 坐标算法
 function get_position_y(font_size, appear_time, text_length, resolution_x, roll_time, array)
     local velocity = (text_length + resolution_x) / roll_time
-    local best_row = 0
-    local best_bias = -math.huge
 
     for i = 1, array.rows do
         local previous_appear_time = array:get_time(i)
@@ -393,7 +391,7 @@ function get_position_y(font_size, appear_time, text_length, resolution_x, roll_
         local delta_velocity = velocity - previous_velocity
         local delta_x = (appear_time - previous_appear_time) * previous_velocity - (previous_length + text_length) / 2
 
-        if delta_x >= 0 then
+        if (appear_time - previous_appear_time) * previous_velocity >= previous_length and delta_x >= 0 then
             if delta_velocity <= 0 then
                 array:set_time_length(i, appear_time, text_length)
                 return 1 + (i - 1) * font_size
@@ -412,9 +410,6 @@ function get_position_y(font_size, appear_time, text_length, resolution_x, roll_
             if bias > 0 then
                 array:set_time_length(i, appear_time, text_length)
                 return 1 + (i - 1) * font_size
-            elseif bias > best_bias then
-                best_bias = bias
-                best_row = i
             end
         end
     end
@@ -424,8 +419,6 @@ end
 
 -- 固定弹幕 Y 坐标算法
 function get_fixed_y(font_size, appear_time, fixtime, array, from_top)
-    local best_row = 0
-    local best_bias = -1
     local row_start, row_end, row_step
     if from_top then
         row_start, row_end, row_step = 1, array.rows, 1
@@ -443,9 +436,6 @@ function get_fixed_y(font_size, appear_time, fixtime, array, from_top)
             if delta_time > fixtime then
                 array:set_time_length(i, appear_time, 0)
                 return (i - 1) * font_size + 1
-            elseif delta_time > best_bias then
-                best_bias = delta_time
-                best_row = i
             end
         end
     end

--- a/modules/parse.lua
+++ b/modules/parse.lua
@@ -389,25 +389,16 @@ function get_position_y(font_size, appear_time, text_length, resolution_x, roll_
         local previous_length = array:get_length(i)
         local previous_velocity = (previous_length + resolution_x) / roll_time
         local delta_velocity = velocity - previous_velocity
-        local delta_x = (appear_time - previous_appear_time) * previous_velocity - (previous_length + text_length) / 2
+        local delta_x = (appear_time - previous_appear_time) * previous_velocity - previous_length
 
-        if (appear_time - previous_appear_time) * previous_velocity >= previous_length and delta_x >= 0 then
+        if delta_x >= 0 then
             if delta_velocity <= 0 then
                 array:set_time_length(i, appear_time, text_length)
                 return 1 + (i - 1) * font_size
             end
 
             local delta_time = delta_x / delta_velocity
-            local bias = appear_time - previous_appear_time - delta_time
-            -- 判断：追及点是否在屏幕之外
-            local t_catch = previous_appear_time + delta_time
-            local distance_prev = previous_velocity * (t_catch - previous_appear_time)
-            if distance_prev > resolution_x then
-                -- 追及发生在屏幕之外，允许放置
-                array:set_time_length(i, appear_time, text_length)
-                return 1 + (i - 1) * font_size
-            end
-            if bias > 0 then
+            if delta_time >= roll_time then
                 array:set_time_length(i, appear_time, text_length)
                 return 1 + (i - 1) * font_size
             end

--- a/modules/render.lua
+++ b/modules/render.lua
@@ -55,7 +55,6 @@ local function parse_ass_events(ass_path, callback)
     end
 
     local events = {}
-    local time_tolerance = options.merge_tolerance
 
     for line in ass_file:lines() do
         if line:match("^Dialogue:") then


### PR DESCRIPTION
Close #291 

之前的弹幕排布逻辑算法只考虑了追击问题时的情况。但实际上存在一种极端的小概率情况，就是前一条弹幕实在太长，长到后一条弹幕直接渲染在了前一条弹幕之上。

根据追击距离`delta_x `的公式`delta_x = (appear_time - previous_appear_time) * previous_velocity - (previous_length + text_length) / 2`，以及追击速度`delta_velocity`的公式`delta_velocity = velocity - previous_velocity`，只要`delta_x > = 0`且`delta_velocity < 0`，理论上就不可能被追上。举个例子，前一条弹幕长度为100px，后一条弹幕长度为1px。假设满足`delta_x > 0`，这只能证明前一条弹幕在后一条弹幕出现之前行进了大于两条弹幕长度一半的距离，也就是50px（短弹幕过短忽略不计），此时前一条弹幕还完全没有渲染完，还有将近一般的长度隐藏在屏幕右侧。这时后一条弹幕就会直接渲染在前一条弹幕上，出现弹幕重叠。又由于短弹幕速度慢于长弹幕，追击速度为负，也就是`delta_velocity < 0`，完美满足了不会被追击的条件。导致重叠弹幕通过条件判断最终被渲染。

也就是说只要前一条弹幕在后一条弹幕出现之前，没有通过长度为`previous_length`的距离，也就是`(appear_time - previous_appear_time) * previous_velocity < previous_length`，后一条弹幕就会跳过追击阶段，直接渲染在前一条弹幕之上。因此需要保证后一条弹幕的出现时间至少要晚于前一条弹幕完全渲染完成的时间戳。

另外顺便删除了一些没有被引用和没有实际作用的变量`best_row`，`best_bias`，`time_tolerance`，应该是之前代码修改时没删干净的残留。