### PR TITLE
feat: add `excluded_platforms` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,48 @@ load_more_danmaku=yes
 
 <details>
 <summary>
+excluded_platforms
+
+> 排除指定平台的弹幕源
+
+</summary>
+
+### excluded_platforms
+
+#### 功能说明
+
+排除指定平台的弹幕源，支持域名关键词匹配。多个平台用逗号分隔。
+
+当启用 `load_more_danmaku` 选项时，脚本会从弹弹play API 获取所有相关弹幕源。此选项允许你过滤掉不想要的平台弹幕。
+
+#### 常见平台
+
+- `bilibili.com` - B站
+- `gamer.com.tw` - 巴哈姆特
+- `acfun.cn` - A站
+- `iqiyi.com` - 爱奇艺
+- `qq.com` - 腾讯视频
+- `youku.com` - 优酷
+
+#### 使用示例
+
+想要开启此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并添加如下内容：
+
+```
+excluded_platforms=["bilibili.com", "gamer.com.tw", "iqiyi.com"]
+```
+
+注意⚠️：
+- 此选项仅在 `load_more_danmaku=yes` 时生效
+- 使用 JSON 数组格式，注意保留方括号和引号
+- 支持域名关键词匹配，不需要精确匹配完整URL
+
+</details>
+
+---
+
+<details>
+<summary>
 auto_load
 
 > 开关全自动弹幕填装

--- a/apis/dandanplay.lua
+++ b/apis/dandanplay.lua
@@ -476,6 +476,47 @@ function handle_fetched_danmaku(data, url, from_menu)
     end
 end
 
+-- 过滤被排除的平台
+function filter_excluded_platforms(relateds)
+    -- 解析排除的平台列表
+    local excluded_list = {}
+    local excluded_json = options.excluded_platforms
+    if excluded_json and excluded_json ~= "" and excluded_json ~= "[]" then
+        local success, parsed = pcall(utils.parse_json, excluded_json)
+        if success and parsed and type(parsed) == "table" then
+            excluded_list = parsed
+        end
+    end
+
+    -- 如果没有排除列表，直接返回原列表
+    if #excluded_list == 0 then
+        return relateds
+    end
+
+    -- 过滤弹幕源
+    local filtered = {}
+    for _, related in ipairs(relateds) do
+        local url = related["url"]
+        local should_exclude = false
+
+        -- 检查URL是否包含任何被排除的平台关键词
+        for _, platform in ipairs(excluded_list) do
+            if url:find(platform, 1, true) then
+                should_exclude = true
+                msg.info(string.format("已排除平台 [%s] 的弹幕源: %s", platform, url))
+                break
+            end
+        end
+
+        if not should_exclude then
+            table.insert(filtered, related)
+        end
+    end
+
+    msg.info(string.format("原始弹幕源: %d 个, 过滤后: %d 个", #relateds, #filtered))
+    return filtered
+end
+
 -- 匹配弹幕库 comment, 仅匹配dandan本身弹幕库
 -- 通过danmaku api（url）+id获取弹幕
 function fetch_danmaku(episodeId, from_menu)
@@ -511,21 +552,22 @@ function fetch_danmaku_all(episodeId, from_menu)
             return
         end
 
-        -- 处理所有的相关弹幕
+        -- 处理所有的相关弹幕，过滤掉被排除的平台
         local relateds = data["relateds"]
+        local filtered_relateds = filter_excluded_platforms(relateds)
         local function process_related(index)
-            if index > #relateds then
+            if index > #filtered_relateds then
                 -- 所有相关弹幕加载完成后，开始加载主库弹幕
                 url = options.api_server .. "/api/v2/comment/" .. episodeId .. "?withRelated=false&chConvert=0"
                 handle_main_danmaku(url, from_menu)
                 return
             end
 
-            local related = relateds[index]
+            local related = filtered_relateds[index]
             local shift = related["shift"]
 
             -- 处理当前的相关弹幕
-            handle_related_danmaku(index, relateds, related, shift, function(comments)
+            handle_related_danmaku(index, filtered_relateds, related, shift, function(comments)
                 if #comments == 0 then
                     if DANMAKU.sources[related["url"]] == nil then
                         DANMAKU.sources[related["url"]] = {from = "api_server"}

--- a/modules/options.lua
+++ b/modules/options.lua
@@ -71,6 +71,11 @@ options = {
     excluded_path = [[
         []
     ]],
+    -- 排除指定平台的弹幕源，支持域名关键词匹配。多个平台用逗号分隔
+    -- 示例：["bilibili.com", "gamer.com.tw"]
+    excluded_platforms = [[
+        []
+    ]],
 }
 
 opt.read_options(options, mp.get_script_name(), function() end)


### PR DESCRIPTION
This pull request introduces a new feature that allows users to exclude specific danmaku (comment) sources from certain platforms when loading more danmaku. The change adds support for keyword-based domain filtering, improves configuration options, and updates documentation to explain usage.

### New feature: Exclude danmaku sources by platform

* Added the `excluded_platforms` option to `modules/options.lua`, allowing users to specify a list of platform domains to exclude from danmaku sources.
* Implemented the `filter_excluded_platforms` function in `apis/dandanplay.lua` to filter out related danmaku sources matching any of the excluded platform keywords.
* Updated the danmaku loading logic in `fetch_danmaku_all` to use the filtered list of sources, ensuring excluded platforms are not loaded.

### Documentation and configuration improvements

* Added a new section in `README.md` that explains the `excluded_platforms` feature, including usage instructions, supported platforms, and configuration examples.