### PR TITLE
修复：覆盖解压避免删除插件目录后解压失败导致插件目录被清空

### DIFF
--- a/modules/update.lua
+++ b/modules/update.lua
@@ -10,7 +10,7 @@ local platform = mp.get_property("platform")
 local function version_greater(v1, v2)
     local function parse(ver)
         local a, b, c = ver:match("v?(%d+)%.(%d+)%.(%d+)")
-        return tonumber(a) or 0, tonumber(b) or 0, tonumber(c) or 0
+        return tonumber(a), tonumber(b), tonumber(c)
     end
     local a1, a2, a3 = parse(v1)
     local b1, b2, b3 = parse(v2)


### PR DESCRIPTION
## 现在有什么问题
使用更新脚本出现：

- 删除目录
- 后续解压中断并报错
- 最终插件目录被清空，更新失败

本 PR 改为 **直接覆盖解压**，避免因删除后续解压失败导致目录内容丢失。