### PR TITLE
将tmdb改为国内大部分地区可以直连的域名

### DIFF
--- a/apis/extra.lua
+++ b/apis/extra.lua
@@ -34,7 +34,7 @@ end
 
 local function query_tmdb(title, class, menu)
     local encoded_title = url_encode(title)
-    local url = string.format("https://api.themoviedb.org/3/search/%s?api_key=%s&query=%s&language=zh-CN",
+    local url = string.format("https://api.tmdb.org/3/search/%s?api_key=%s&query=%s&language=zh-CN",
     class, Base64.decode(options.tmdb_api_key), encoded_title)
 
     local cmd = {


### PR DESCRIPTION
RT
用ai做[这个PR](https://github.com/huangxd-/danmu_api/pull/67)才知道还有直连的域名（）我没有查到`api.tmdb.org`这个域名出自哪，但查了WHOIS信息看起来是非常悠远可靠的，应该是出自官方
<img width="1616" height="941" alt="image" src="https://github.com/user-attachments/assets/c3e91fae-bb28-4705-9e9e-fb7927d10924" />
<img width="1021" height="929" alt="image" src="https://github.com/user-attachments/assets/31008c6a-208d-4c68-870b-b8783944a76f" />
