### PR TITLE
feat: support xml fallback danmaku file

### DIFF
--- a/apis/dandanplay.lua
+++ b/apis/dandanplay.lua
@@ -63,6 +63,16 @@ function get_danmaku_fallback(query)
     if not args then return end
 
     fetch_danmaku_data(args, function(data)
+        if data ~= nil and data["xml"] ~= nil then
+            if DANMAKU.sources[query] ~= nil then
+                DANMAKU.sources[query]["data"] = data["xml"]
+            else
+                DANMAKU.sources[query] = {from = "user_custom", data = data["xml"]}
+            end
+            load_danmaku(true)
+            return
+        end
+
         if not data or not data["comments"] or data["count"] <= 1 then
             msg.info("备用服务器无数据或返回格式不正确")
             show_message("备用服务器无数据或返回格式不正确", 3)
@@ -100,6 +110,8 @@ function make_danmaku_request_args(method, url, headers, body)
         table.insert(args, '-H')
         table.insert(args, 'Content-Type: application/json')
     end
+
+    table.insert(args, '--compressed')
 
     if url:find("api%.dandanplay%.") then
         local time = os.time()
@@ -370,7 +382,15 @@ function fetch_danmaku_data(args, callback)
             return
         end
         local data = utils.parse_json(json)
-        data = normalize_danmaku_response(data)
+        if data ~= nil then
+            data = normalize_danmaku_response(data)
+        else
+            local danmaku = parse_xml_danmaku(json)
+            if #danmaku > 0 then
+                data = {}
+                data["xml"] = danmaku
+            end
+        end
         callback(data)
     end)
 end

--- a/modules/parse.lua
+++ b/modules/parse.lua
@@ -327,8 +327,11 @@ local function limit_danmaku(danmakus, limit)
 end
 
 -- 解析 XML 弹幕
-local function parse_xml_danmaku(xml_string)
+function parse_xml_danmaku(xml_string)
     local danmakus = {}
+    if not xml_string then
+        return danmakus
+    end
     -- [^>]* 匹配其他 attributes
     -- %f[^%s] 确保 p= 前面是空白字符
     for p_attr, text in xml_string:gmatch('<d%s+[^>]*%f[^%s]p="([^"]+)"[^>]*>([^<]+)</d>') do

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -214,6 +214,9 @@ end
 function hex_to_int_color(hex_color)
     -- 移除颜色代码中的'#'字符
     hex_color = hex_color:sub(2)  -- 只保留颜色代码部分
+    if not hex_color:match("^%x%x%x%x%x%x$") then
+        return 16777215
+    end
 
     -- 提取R, G, B的十六进制值并转为整数
     local r = tonumber(hex_color:sub(1, 2), 16)


### PR DESCRIPTION
Close #373

对于备用弹幕服务器返回形如`<d p="3.84800,4,25,15138834,1605642675,0,f6809e83,41156870239420421,10">text</d>`格式的XML弹幕文件的情况进行了支持。顺便修复了hex颜色格式不规范导致的异常退出。

另外这个pr意外使得fallback_server重新兼容了 https://github.com/lyz05/danmaku 项目的弹幕解析接口，`?ac=dm&url=`中多余的ac查询参数不影响 https://github.com/lyz05/danmaku 的接口正常进行解析。