### PR TITLE
feat: support custom danmaku save path #390

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ key script-message danmaku-delay <seconds> ${=time-pos}
 
 > #### 保存当前视频弹幕（可选）
 
-在视频播放时手动保存弹幕至视频所在文件夹，保存格式为 `xml`（注：此功能将保存为视频同名弹幕，若视频文件夹下存在同名文件将不会执行该功能）
+在视频播放时手动保存弹幕，保存格式为 `xml`（注：此功能将保存为视频同名弹幕，若目标文件夹下存在同名文件将不会执行该功能）。默认保存至视频所在文件夹，也可以通过 `save_danmaku_path` 和 `save_danmaku_path_mode` 保存到指定文件夹。
 
 想要通过快捷键使用此功能，请添加类似下面的配置到 `input.conf`中。从源添加弹幕功能对应的脚本消息为 `immediately_save_danmaku`。
 
@@ -504,7 +504,7 @@ save_danmaku
 
 #### 功能说明
 
-当文件关闭时自动保存弹幕文件（xml格式）至视频同目录，保存的弹幕文件名与对应的视频文件名相同。配合[autoload_local_danmaku选项](#autoload_local_danmaku)可以实现弹幕自动保存到本地并且下次播放时自动加载本地保存的弹幕。此功能默认禁用。
+当文件关闭时自动保存弹幕文件（xml格式），保存的弹幕文件名与对应的视频文件名相同。默认保存至视频同目录，配合[autoload_local_danmaku选项](#autoload_local_danmaku)可以实现弹幕自动保存到本地并且下次播放时自动加载本地保存的弹幕。此功能默认禁用。
 
 > **⚠️NOTE！**
 > 
@@ -522,6 +522,32 @@ save_danmaku
 
 ```
 save_danmaku=yes
+```
+
+如需保存到指定文件夹，请提前创建目标文件夹，然后配置 `save_danmaku_path` 和 `save_danmaku_path_mode`。插件不会自动创建目录。
+
+保存本地媒体到指定文件夹时，文件名会包含视频父目录名，用于减少不同目录下同名视频的弹幕文件冲突。例如 `动画/01.mkv` 会保存为类似 `动画_01.xml`。网络媒体保存到指定文件夹时仍使用媒体标题作为文件名。
+
+`save_danmaku_path_mode` 可选值如下：
+
+- `local`：默认值，仅本地媒体保存到 `save_danmaku_path`，网络媒体仍不保存
+- `url`：仅网络媒体保存到 `save_danmaku_path`，本地媒体仍保存到视频同目录
+- `all`：本地媒体和网络媒体都保存到 `save_danmaku_path`
+
+例如，仅将网络媒体的弹幕保存到 `~~/danmaku`：
+
+```
+save_danmaku=yes
+save_danmaku_path=~~/danmaku
+save_danmaku_path_mode=url
+```
+
+例如，将所有媒体的弹幕都保存到 `~~/danmaku`：
+
+```
+save_danmaku=yes
+save_danmaku_path=~~/danmaku
+save_danmaku_path_mode=all
 ```
 
 </details>

--- a/main.lua
+++ b/main.lua
@@ -493,14 +493,48 @@ function read_danmaku_source_record(path)
     end
 end
 
+local function get_save_danmaku_output(path, filename)
+    if not path or not filename then return nil end
+
+    local custom_dir = options.save_danmaku_path ~= "" and
+        mp.command_native({"expand-path", options.save_danmaku_path}) or nil
+    local is_url = is_protocol(path)
+    local mode = options.save_danmaku_path_mode
+    local dir = nil
+
+    if mode ~= "url" and mode ~= "all" then
+        mode = "local"
+    end
+
+    if custom_dir and (mode == "all" or (mode == "url" and is_url) or (mode == "local" and not is_url)) then
+        local output_name = sanitize_filename(filename)
+        if not is_url then
+            dir = get_parent_directory(path)
+            local _, parent_name = dir and utils.split_path(dir:sub(1, -2))
+            if parent_name and parent_name ~= "" then
+                output_name = sanitize_filename(parent_name .. "_" .. filename)
+            end
+        end
+        return utils.join_path(custom_dir, output_name .. ".xml")
+    end
+
+    if is_url then
+        return nil
+    end
+
+    dir = get_parent_directory(path)
+    if not dir then
+        return nil
+    end
+    return utils.join_path(dir, filename .. ".xml")
+end
+
 -- 视频播放时保存弹幕
 function save_danmaku(not_forced)
     local path = mp.get_property("path")
-    local dir = get_parent_directory(path) or ""
-    local filename = mp.get_property('filename/no-ext')
-    local danmaku_out = utils.join_path(dir, filename .. ".xml")
-    -- 排除网络播放场景
-    if not path or is_protocol(path) or (not file_exists(danmaku_out)
+    local filename = is_protocol(path) and mp.get_property("media-title") or mp.get_property('filename/no-ext')
+    local danmaku_out = get_save_danmaku_output(path, filename)
+    if not danmaku_out or (not file_exists(danmaku_out)
     and not is_writable(danmaku_out)) then
         show_message("此弹幕文件不支持保存至本地")
         msg.warn("此弹幕文件不支持保存至本地")

--- a/modules/options.lua
+++ b/modules/options.lua
@@ -17,6 +17,10 @@ options = {
     autoload_local_danmaku = false,
     autoload_for_url = false,
     save_danmaku = false,
+    -- 指定弹幕保存目录。为空时保存到视频同目录；目录需要用户提前创建
+    save_danmaku_path = "",
+    -- 指定 save_danmaku_path 的应用范围：local / url / all
+    save_danmaku_path_mode = "local",
     user_agent = "mpv_danmaku/1.0",
     proxy = "",
     -- 可选：向 HTTP 请求传递 cookie.txt 文件路径

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -201,6 +201,18 @@ function is_protocol(path)
     return type(path) == 'string' and (path:find('^%a[%w.+-]-://') ~= nil or path:find('^%a[%w.+-]-:%?') ~= nil)
 end
 
+function sanitize_filename(name)
+    if not name or name == "" then
+        return "danmaku"
+    end
+    name = name:gsub('[/\\:*?"<>|]', "_")
+               :gsub('^%s*(.-)%s*$', '%1')
+    if name == "" then
+        return "danmaku"
+    end
+    return name
+end
+
 function hex_to_bin(hexstr)
     return (hexstr:gsub('..', function (cc)
         return string.char(tonumber(cc, 16))


### PR DESCRIPTION
Close #390 

新增 `save_danmaku_path` 配置项，用于指定弹幕保存目录。新增 `save_danmaku_path_mode` 配置项，用于控制指定保存目录的应用范围，默认值为 `local`。

配置 `save_danmaku_path` 后，`save_danmaku_path_mode` 支持以下模式：

- `local`：仅本地媒体保存到 `save_danmaku_path`，网络媒体仍不保存。
- `url`：仅网络媒体保存到 `save_danmaku_path`，本地媒体仍保存到视频同目录。
- `all`：本地媒体和网络媒体都保存到 `save_danmaku_path`。