### PR TITLE
feat: add option to limit danmaku by numbers per 10 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,34 @@ max_screen_danmaku=60
 
 <details>
 <summary>
+max_danmaku_rate
+
+> 限制每10秒钟新出现的弹幕数量
+
+</summary>
+
+### max_danmaku_rate
+
+#### 功能说明
+
+当该值大于0时，脚本会在解析弹幕时，从每10秒的新弹幕中随机保留一部分，最多不超过设定值。
+
+当 `max_screen_danmaku` 大于0时，该配置项不生效。
+
+#### 使用方法
+
+在 `script-opts` 目录下创建 `uosc_danmaku.conf` 并添加如下内容：
+
+```
+max_danmaku_rate=20
+```
+
+</details>
+
+---
+
+<details>
+<summary>
 vf_fps
 
 > 开关使用fps视频滤镜提升弹幕平滑度（帧数）

--- a/modules/options.lua
+++ b/modules/options.lua
@@ -59,6 +59,8 @@ options = {
     outline = 1.0,
     -- 限制屏幕中同时显示的最大弹幕数量，0 表示不限制
     max_screen_danmaku = 0,
+    -- 限制每秒新出现的弹幕数量，0 表示不限制, 只在 max_screen_danmaku 为 0 时生效
+    max_danmaku_rate = 0,
     --指定弹幕屏蔽词文件路径(black.txt)，支持绝对路径和相对路径。文件内容以换行分隔
     --支持 lua 的正则表达式写法
     blacklist_path = "",

--- a/modules/options.lua
+++ b/modules/options.lua
@@ -59,7 +59,7 @@ options = {
     outline = 1.0,
     -- 限制屏幕中同时显示的最大弹幕数量，0 表示不限制
     max_screen_danmaku = 0,
-    -- 限制每秒新出现的弹幕数量，0 表示不限制, 只在 max_screen_danmaku 为 0 时生效
+    -- 限制每 10 秒新出现的弹幕数量，0 表示不限制, 只在 max_screen_danmaku 不限制时生效
     max_danmaku_rate = 0,
     --指定弹幕屏蔽词文件路径(black.txt)，支持绝对路径和相对路径。文件内容以换行分隔
     --支持 lua 的正则表达式写法

--- a/modules/parse.lua
+++ b/modules/parse.lua
@@ -326,7 +326,7 @@ local function limit_danmaku(danmakus, limit)
     return result
 end
 
--- 限制每秒弹幕条数
+-- 限制每 10 秒弹幕条数
 local function limit_danmaku_by_rate(danmakus, max_rate)
     if not max_rate or max_rate <= 0 then
         return danmakus
@@ -338,9 +338,8 @@ local function limit_danmaku_by_rate(danmakus, max_rate)
     local result = {}
 
     while l <= n do
-        local current_second = math.floor(danmakus[l].start_time)
-        r = l
-        while r <= n and danmakus[r].start_time < current_second+1 do
+        local current_group = math.floor(danmakus[l].start_time / 10) * 10
+        while r <= n and danmakus[r].start_time < current_group+10 do
             r = r + 1
         end
 

--- a/modules/parse.lua
+++ b/modules/parse.lua
@@ -326,6 +326,37 @@ local function limit_danmaku(danmakus, limit)
     return result
 end
 
+-- 限制每秒弹幕条数
+local function limit_danmaku_by_rate(danmakus, max_rate)
+    if not max_rate or max_rate <= 0 then
+        return danmakus
+    end
+
+    local l = 1
+    local r = 1
+    local n = #danmakus
+    local result = {}
+
+    while l <= n do
+        local current_second = math.floor(danmakus[l].start_time)
+        r = l
+        while r <= n and danmakus[r].start_time < current_second+1 do
+            r = r + 1
+        end
+
+        local need = max_rate
+        for i = l, r-1 do
+            if need == 0 then break end
+            if math.random(r - i) <= need then
+                table.insert(result, danmakus[i])
+                need = need - 1
+            end
+        end
+        l = r
+    end
+    return result
+end
+
 -- 解析 XML 弹幕
 function parse_xml_danmaku(xml_string)
     local danmakus = {}
@@ -705,6 +736,8 @@ function convert_danmaku_to_ass_events(force)
 
     if options.max_screen_danmaku > 0 then
         pre_events = limit_danmaku(pre_events, options.max_screen_danmaku)
+    elseif options.max_danmaku_rate > 0 then
+        pre_events = limit_danmaku_by_rate(pre_events, options.max_danmaku_rate)
     end
 
     local ass_events = {}


### PR DESCRIPTION
本PR增添了一个降低弹幕密度的配置项，`max_danmaku_rate`，代表每10秒钟新出现的弹幕数上限。

原理是对于每10秒的弹幕，均匀的随机抽选设定值个数，其他的都丢弃，框架和原有的`max_screen_danmaku`是一样的。

我自己用起来没什么问题，跟`max_screen_danmaku`比，视觉上看起来更均匀，所以提出了这个PR，如果有用话希望能合并，谢谢！