### PR TITLE
fix: hash calculation skipped when the file size is exactly 16 MB

### DIFF
--- a/apis/dandanplay.lua
+++ b/apis/dandanplay.lua
@@ -349,7 +349,7 @@ local function match_file(file_path, file_name, callback)
     -- 计算文件哈希
     local hash = nil
     local file_info = utils.file_info(file_path)
-    if file_info and file_info.size > 16 * 1024 * 1024 then
+    if file_info and file_info.size >= 16 * 1024 * 1024 then
         local file, error = io.open(normalize(file_path), 'rb')
         if file and not error then
             local m = MD5.new()


### PR DESCRIPTION
当通过远端url播放时（如播放emby上的资源），会因获取到的文件大小恰好等于16MB而无法触发哈希计算，影响弹幕获取。