### PR TITLE
fix: Replace fallback_server

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,9 +800,11 @@ api_server
 
 允许自定义弹幕 API 的服务地址。默认使用项目维护的 `https://danmaku-api.152468.xyz`，由代理完成弹弹play API 鉴权，插件用户无需配置密钥。
 
-可指定多个用逗号分隔的有序 api_server 列表。
+可指定多个用逗号分隔的有序 api_server 列表（`有序`是指搜索结果将依据相同剧集 ID，在 api_server 中的顺序向前合并成一项）。
 
 支持每项使用 '|' 或 '#' 分隔备注，例如: "https://a.example.com|备用A" 或 "https://b.example.com#备用B"
+
+多 api_server 时搜索剧集，可以使用 ”剧集名称@server备注“ 的形式指定备注匹配 api_server 单一检索
 
 > **⚠️NOTE！**
 > 
@@ -834,18 +836,20 @@ fallback_server
 
 #### 功能说明
 
-自定义 b 站和爱腾优的弹幕获取的兜底服务器地址，主要用于获取非动画弹幕，只有在弹弹play无法解析视频源对应弹幕的情况下才会使用此处设置的服务器进行解析。可用： https://api.danmu.icu，https://dmku.hls.one
+自定义 b 站和爱腾优的弹幕获取的兜底服务器地址，主要用于获取非动画弹幕，只有在配置的所有 **`api_server`** 以及插件内置的 `站点专用解析器` 都无法解析视频源对应弹幕的情况下，才会使用此处设置的服务器进行解析。可用：https://dmku.hls.one
 
 > **⚠️NOTE！**
-> 
-> 不设置此选项的情况下默认使用 ` https://api.danmu.icu`作为兜底服务器
+>
+> 插件已在 `sites` 目录下内置了各大常规视频网站的弹幕站点专用解析器（[#377](https://github.com/Tony15246/uosc_danmaku/pull/377) [#380](https://github.com/Tony15246/uosc_danmaku/pull/380)），仅当专用解析器都无法解析获取站点弹幕时才会使用兜底服务器
+>
+> 不设置此选项的情况下默认使用 ` https://dmku.hls.one`作为兜底服务器
 
 #### 使用方法
 
 想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并自定义如下内容：
 
 ```
-fallback_server=https://api.danmu.icu
+fallback_server=https://dmku.hls.one
 ```
 
 </details>

--- a/modules/options.lua
+++ b/modules/options.lua
@@ -7,8 +7,8 @@ options = {
     -- 支持每项使用 '|' 或 '#' 分隔备注，例如: "https://a.example.com|备用A" 或 "https://b.example.com#备用B"
     api_server = "https://danmaku-api.152468.xyz",
     -- 指定 b 站和爱腾优的弹幕获取的兜底服务器地址，主要用于获取非动画弹幕
-    -- 可用： https://api.danmu.icu，https://dmku.hls.one
-    fallback_server = "https://api.danmu.icu",
+    -- 可用： https://dmku.hls.one
+    fallback_server = "https://dmku.hls.one",
     -- 设置 tmdb 的 API Key，用于获取非动画条目的中文信息(当搜索内容非中文时)
     -- 可以在 https://www.themoviedb.org 注册后去个人账号设置界面获取
     -- 注意：自定义此参数时还需要对获取到的 API Key 进行 base64 编码
@@ -27,7 +27,9 @@ options = {
     save_danmaku_path = "",
     -- 指定 save_danmaku_path 的应用范围：local / url / all
     save_danmaku_path_mode = "local",
+    -- 向 HTTP 请求时使用的 User Agent
     user_agent = "mpv_danmaku/1.0",
+    -- 可选：向 HTTP 请求时使用的代理，默认禁用
     proxy = "",
     -- 可选：向 HTTP 请求传递 cookie.txt 文件路径
     cookie_file = "",
@@ -41,6 +43,7 @@ options = {
     merge_without_style = false,
     -- 指定弹幕关联历史记录文件的路径，支持绝对路径和相对路径
     history_path = "~~/danmaku-history.json",
+    -- 自定义插件快捷键，若 mpv.conf 里设置 input-default-bindings=no 将禁用以下两个选项
     open_search_danmaku_menu_key = "Ctrl+d",
     show_danmaku_keyboard_key = "j",
     -- 中文简繁转换。0-不转换，1-转换为简体，2-转换为繁体


### PR DESCRIPTION
默认fallback_server：https://api.danmu.icu ，已无法使用，现进行删除更换