### PR TITLE
feat: dynamic merged danmaku fontsize increase

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,60 @@ merge_without_style=yes
 
 <details>
 <summary>
+merge_fontsize_growth
+
+> 设置合并弹幕字号随合并数量增长的速度
+
+</summary>
+
+### merge_fontsize_growth
+
+#### 功能说明
+
+配合 `merge_tolerance` 使用，默认值为 `8`，必须为正整数。设基础字号为 `fontsize`、合并数量为 `n`，实际字号为：
+
+```
+min(merge_fontsize_max, fontsize + round(merge_fontsize_growth * ln(n)))
+```
+
+取整前的对数函数严格递增且严格凹，因此合并数量较小时放大明显，随后每多合并一条弹幕带来的字号增量逐渐减小。取整后的整数字号单调不减，并受 `merge_fontsize_max` 限制。字号较大的弹幕会按实际高度占用连续的 y 轴区间；屏幕可显示区域内找不到无碰撞位置时，该条弹幕会被丢弃。
+
+#### 使用方法
+
+```
+merge_fontsize_growth=8
+```
+
+</details>
+
+---
+
+<details>
+<summary>
+merge_fontsize_max
+
+> 限制合并弹幕的最大字号
+
+</summary>
+
+### merge_fontsize_max
+
+#### 功能说明
+
+配合 `merge_fontsize_growth` 使用，默认值为 `100`。无论合并数量多大，最终字号都不会超过该值；如果该值小于基础字号 `fontsize`，则使用基础字号。
+
+#### 使用方法
+
+```
+merge_fontsize_max=100
+```
+
+</details>
+
+---
+
+<details>
+<summary>
 max_screen_danmaku
 
 > 限制屏幕中同时显示的弹幕数量

--- a/modules/options.lua
+++ b/modules/options.lua
@@ -39,6 +39,10 @@ options = {
     merge_tolerance = -1,
     -- 合并重复弹幕时是否强制合并类型和颜色不同的弹幕。默认值: false，表示仅合并类型和颜色相同的弹幕
     merge_without_style = false,
+    -- 合并弹幕字号的对数增长系数，必须为正整数
+    merge_fontsize_growth = 8,
+    -- 合并弹幕允许使用的最大字号
+    merge_fontsize_max = 100,
     -- 指定弹幕关联历史记录文件的路径，支持绝对路径和相对路径
     history_path = "~~/danmaku-history.json",
     open_search_danmaku_menu_key = "Ctrl+d",

--- a/modules/parse.lua
+++ b/modules/parse.lua
@@ -228,7 +228,7 @@ local function merge_duplicate_danmaku(danmakus, threshold)
                         end
                     end
                 end
-                
+
                 for _, cg in ipairs(color_groups) do
                     table.insert(final_groups, cg)
                 end
@@ -271,6 +271,7 @@ local function merge_duplicate_danmaku(danmakus, threshold)
                 text = base.text,
                 source = base.source,
                 orig_time = base.orig_time,
+                merge_count = count,
             }
             if count > 2 or not same_time then
                 danmaku.text = danmaku.text .. string.format("x%d", count)
@@ -437,104 +438,137 @@ end
 local DanmakuArray = {}
 DanmakuArray.__index = DanmakuArray
 
-function DanmakuArray:new(res_x, res_y, font_size)
+-- 取整前的对数映射严格递增且严格凹。
+-- 取整后的整数字号单调不减，最大字号用于避免合并数量过大时字号失控。
+function DanmakuArray.get_merged_font_size(base_size, count, growth, max_size)
+    local base = positive_integer(base_size, 1)
+    local n = positive_integer(count, 1)
+    local scale = positive_integer(growth, 8)
+    local maximum = math.max(base, positive_integer(max_size, base))
+    local size = base + math.floor(scale * math.log(n) + 0.5)
+    return math.min(maximum, size)
+end
+
+function DanmakuArray:new(max_y)
     local obj = {
-        solution_y = res_y,
-        font_size = font_size,
-        rows = math.floor(res_y / font_size),
-        time_length_array = {}
+        max_y = positive_integer(max_y, 1),
+        danmakus = {},
     }
-    for i = 1, obj.rows do
-        obj.time_length_array[i] = { time = 0, length = 0, empty = true }
-    end
     setmetatable(obj, self)
     return obj
 end
 
-function DanmakuArray:set_time_length(row, time, length)
-    if row > 0 and row <= self.rows then
-        self.time_length_array[row] = { time = time, length = length, empty = false }
-    end
-end
-
-function DanmakuArray:get_time(row)
-    if row > 0 and row <= self.rows then
-        return self.time_length_array[row].time
-    end
-    return -1
-end
-
-function DanmakuArray:get_length(row)
-    if row > 0 and row <= self.rows then
-        return self.time_length_array[row].length
-    end
-    return 0
-end
-
-function DanmakuArray:is_empty(row)
-    if row > 0 and row <= self.rows then
-        return self.time_length_array[row].empty
-    end
-    return false
-end
-
--- 滚动弹幕 Y 坐标算法
-function get_position_y(font_size, appear_time, text_length, resolution_x, roll_time, array)
-    local velocity = (text_length + resolution_x) / roll_time
-
-    for i = 1, array.rows do
-        local previous_appear_time = array:get_time(i)
-        if array:is_empty(i) then
-            array:set_time_length(i, appear_time, text_length)
-            return 1 + (i - 1) * font_size
-        end
-
-        local previous_length = array:get_length(i)
-        local previous_velocity = (previous_length + resolution_x) / roll_time
-        local delta_velocity = velocity - previous_velocity
-        local delta_x = (appear_time - previous_appear_time) * previous_velocity - previous_length
-
-        if delta_x >= 0 then
-            if delta_velocity <= 0 then
-                array:set_time_length(i, appear_time, text_length)
-                return 1 + (i - 1) * font_size
-            end
-
-            local delta_time = delta_x / delta_velocity
-            if delta_time >= roll_time then
-                array:set_time_length(i, appear_time, text_length)
-                return 1 + (i - 1) * font_size
-            end
+-- 弹幕按出现时间递增的顺序处理。滚动弹幕完全移出屏幕后，或固定弹幕的
+-- 显示时间结束后，它便不可能与当前及之后的弹幕碰撞，因此可以安全删除。
+function DanmakuArray:remove_expired(now)
+    for i = #self.danmakus, 1, -1 do
+        if self.danmakus[i].end_time <= now then
+            table.remove(self.danmakus, i)
         end
     end
-    -- 所有行都被占用，放弃渲染
+end
+
+local function y_intersects(y1, height1, y2, height2)
+    return y1 < y2 + height2 and y2 < y1 + height1
+end
+
+local function rolling_danmaku_collides(previous, start_time, velocity)
+    local delta_velocity = velocity - previous.velocity
+    local delta_x = (start_time - previous.start_time) * previous.velocity - previous.length
+
+    -- delta_x 小于 0 表示旧弹幕尾部尚未进入屏幕，新弹幕出现时会直接重叠。
+    if delta_x < 0 then
+        return true
+    end
+
+    -- 新弹幕速度不大于旧弹幕时，不会缩短已有的 delta_x 间距。
+    if delta_velocity <= 0 then
+        return false
+    end
+
+    -- 比较从新弹幕出现开始的追尾时间与旧弹幕的剩余显示时间；
+    -- 只有在旧弹幕离屏前追上它，才会发生碰撞。
+    local delta_time = delta_x / delta_velocity
+    local remaining_time = previous.end_time - start_time
+    return delta_time < remaining_time
+end
+
+-- 从 y 轴顶部开始寻找可插入位置。对于每个候选位置，只检查 y 轴区间
+-- 与新弹幕相交的已有弹幕；若其中存在碰撞，则跳到碰撞区间下方继续寻找。
+local function find_y_from_top(array, height, collides)
+    local y = 1
+    while y + height - 1 <= array.max_y do
+        local next_y = nil
+        for _, danmaku in ipairs(array.danmakus) do
+            if y_intersects(y, height, danmaku.y, danmaku.height) and collides(danmaku) then
+                local below = danmaku.y + danmaku.height
+                next_y = next_y and math.max(next_y, below) or below
+            end
+        end
+        if not next_y then return y end
+        y = next_y
+    end
     return nil
 end
 
--- 固定弹幕 Y 坐标算法
-function get_fixed_y(font_size, appear_time, fixtime, array, from_top)
-    local row_start, row_end, row_step
+-- 从 y 轴顶部开始寻找滚动弹幕的位置，并记录成功插入的弹幕所占区间。
+function DanmakuArray:get_position_y(start_time, length, height, resolution_x, duration)
+    height = positive_integer(height, 1)
+    length = math.max(0, tonumber(length) or 0)
+    resolution_x = math.max(1, tonumber(resolution_x) or 1)
+    duration = math.max(0.001, tonumber(duration) or 0.001)
+    self:remove_expired(start_time)
+
+    local velocity = (length + resolution_x) / duration
+    local y = find_y_from_top(self, height, function(previous)
+        return rolling_danmaku_collides(previous, start_time, velocity)
+    end)
+    if not y then return nil end
+
+    self.danmakus[#self.danmakus + 1] = {
+        y = y,
+        height = height,
+        start_time = start_time,
+        end_time = start_time + duration,
+        length = length,
+        velocity = velocity,
+    }
+    return y
+end
+
+-- 顶部固定弹幕自上而下寻找位置，底部固定弹幕则自下而上寻找位置。
+function DanmakuArray:get_fixed_y(start_time, height, duration, from_top)
+    height = positive_integer(height, 1)
+    duration = math.max(0.001, tonumber(duration) or 0.001)
+    self:remove_expired(start_time)
+
+    local y
     if from_top then
-        row_start, row_end, row_step = 1, array.rows, 1
+        y = find_y_from_top(self, height, function() return true end)
     else
-        row_start, row_end, row_step = array.rows, 1, -1
+        y = self.max_y - height + 1
+        while y >= 1 do
+            local next_y = nil
+            for _, danmaku in ipairs(self.danmakus) do
+                if y_intersects(y, height, danmaku.y, danmaku.height) then
+                    local above = danmaku.y - height
+                    next_y = next_y and math.min(next_y, above) or above
+                end
+            end
+            if not next_y then break end
+            y = next_y
+        end
+        if y < 1 then y = nil end
     end
 
-    for i = row_start, row_end, row_step do
-        local previous_appear_time = array:get_time(i)
-        if array:is_empty(i) then
-            array:set_time_length(i, appear_time, 0)
-            return (i - 1) * font_size + 1
-        else
-            local delta_time = appear_time - previous_appear_time
-            if delta_time > fixtime then
-                array:set_time_length(i, appear_time, 0)
-                return (i - 1) * font_size + 1
-            end
-        end
-    end
-    -- 所有行都被占用，放弃渲染
-    return nil
+    if not y then return nil end
+    self.danmakus[#self.danmakus + 1] = {
+        y = y,
+        height = height,
+        start_time = start_time,
+        end_time = start_time + duration,
+    }
+    return y
 end
 
 -- 将弹幕转换为 XML 格式
@@ -674,14 +708,17 @@ function convert_danmaku_to_ass_events(force)
     end
 
     local fontsize = tonumber(options.fontsize) or 50
+    local fontsize_growth = tonumber(options.merge_fontsize_growth) or 8
+    local fontsize_max = tonumber(options.merge_fontsize_max) or 100
     local scrolltime = tonumber(options.scrolltime) or 15
     local fixtime = tonumber(options.fixtime) or 5
 
     local res_x = 1920
     local res_y = 1080
 
-    local roll_array = DanmakuArray:new(res_x, res_y, fontsize)
-    local top_array = DanmakuArray:new(res_x, res_y, fontsize)
+    local display_height = math.max(1, math.floor(res_y * (tonumber(options.displayarea) or 1)))
+    local roll_array = DanmakuArray:new(display_height)
+    local fixed_array = DanmakuArray:new(display_height)
 
     -- 预处理弹幕，先计算时间段以便进行数量限制
     local pre_events = {}
@@ -715,6 +752,9 @@ function convert_danmaku_to_ass_events(force)
         local clean_text = ch_convert_cached(decode_html_entities(d.text))
         local text = ass_escape(clean_text)
                     :gsub("x(%d+)$", "{\\b1\\i1}x%1")
+        local event_fontsize = DanmakuArray.get_merged_font_size(
+            fontsize, d.merge_count or 1, fontsize_growth, fontsize_max
+        )
 
         -- 颜色从十进制转为 BGR Hex
         local color = math.max(0, math.min(d.color or 0xFFFFFF, 0xFFFFFF))
@@ -730,10 +770,10 @@ function convert_danmaku_to_ass_events(force)
         -- 滚动弹幕 (类型 1, 2, 3)
         if danmaku_type >= 1 and danmaku_type <= 3 then
             style = "R2L"
-            local text_length = get_str_width(text, fontsize)
+            local text_length = get_str_width(clean_text, event_fontsize)
             local x1 = res_x + text_length / 2
             local x2 = -text_length / 2
-            local y = get_position_y(fontsize, appear_time, text_length, res_x, scrolltime, roll_array)
+            local y = roll_array:get_position_y(appear_time, text_length, event_fontsize, res_x, scrolltime)
             if y then
                 effect = string.format("{\\move(%d, %d, %d, %d)}", x1, y, x2, y)
                 move = {x1, y, x2, y}
@@ -743,7 +783,7 @@ function convert_danmaku_to_ass_events(force)
         elseif danmaku_type == 5 then
             style = "TOP"
             local x = res_x / 2
-            local y = get_fixed_y(fontsize, appear_time, fixtime, top_array, true)
+            local y = fixed_array:get_fixed_y(appear_time, event_fontsize, fixtime, true)
             if y then
                 effect = string.format("{\\pos(%d, %d)}", x, y)
                 pos = {x, y}
@@ -753,7 +793,7 @@ function convert_danmaku_to_ass_events(force)
         elseif danmaku_type == 4 then
             style = "BTM"
             local x = res_x / 2
-            local y = get_fixed_y(fontsize, appear_time, fixtime, top_array, false)
+            local y = fixed_array:get_fixed_y(appear_time, event_fontsize, fixtime, false)
             if y then
                 effect = string.format("{\\pos(%d, %d)}", x, y)
                 pos = {x, y}
@@ -774,9 +814,11 @@ function convert_danmaku_to_ass_events(force)
                 move = move,
                 layer = (style == "R2L") and 0 or 1,
                 source = d.source,
+                font_size = event_fontsize,
+                merge_count = d.merge_count or 1,
             }
             table.insert(ass_events, event)
-            COMMENTS = ass_events
         end
     end
+    COMMENTS = ass_events
 end

--- a/modules/render.lua
+++ b/modules/render.lua
@@ -101,7 +101,13 @@ function render(pos_arg)
             end
 
             -- 构建 ASS 字符串
-            local ass_text = text and (ass_prefix .. text)
+            local event_font_prefix = ""
+            if event.font_size then
+                local configured_size = tonumber(options.fontsize) or fontsize
+                local adjusted_size = math.max(1, math.floor(event.font_size + fontsize - configured_size))
+                event_font_prefix = string.format("{\\fs%d}", adjusted_size)
+            end
+            local ass_text = text and (ass_prefix .. event_font_prefix .. text)
             if ass_text then
                 if event.layer == nil or tonumber(event.layer) == 0 then
                     table.insert(ass_events_low, ass_text)

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -4,6 +4,11 @@ local unpack = unpack or table.unpack
 -- from http://lua-users.org/wiki/LuaUnicode
 local UTF8_PATTERN = '[%z\1-\127\194-\244][\128-\191]*'
 
+function positive_integer(value, fallback)
+    value = math.floor(tonumber(value) or fallback)
+    return math.max(1, value)
+end
+
 -- return a substring based on utf8 characters
 -- like string.sub, but negative index is not supported
 function utf8_sub(s, i, j)


### PR DESCRIPTION
Close #404

重构原本的固定轨道弹幕数组，改为对于弹幕队列中的每条弹幕，记录其占据了y轴的哪一段。y位置算法从原本遍历所有轨道，改为从y轴原点开始遍历，找出弹幕队列中之前的弹幕和现在弹幕在y轴上有交集的所有弹幕，逐一计算是否会碰撞，只有全都不发生碰撞，才可以插入该位置；假如存在碰撞，则找到发生碰撞的弹幕中，y轴坐标最大的弹幕，从它的下面继续遍历是否能插入，假如遍历完整个y轴都无法插入，则放弃插入。弹幕完全移出屏幕后，会被从弹幕数组中删除。

合并弹幕放大是一个从合并的弹幕数量到正整数弹幕字号的映射，该映射为单调递增的严格凹函数，保证弹幕字号随合并弹幕数量增长的同时，增长速度递减。实际实现中采用对数映射，公式为`min(merge_fontsize_max, fontsize + round(merge_fontsize_growth * ln(n)))`,其中`merge_fontsize_growth`为增长系数，`merge_fontsize_max`为最大字号。