### PR TITLE
feat: 增加弹幕搜索历史功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -1127,6 +1127,64 @@ history_path=/path/to/your/danmaku-history.json
 
 ---
 
+<details>
+<summary>
+search_history_path
+
+> 指定弹幕搜索历史记录文件路径
+
+</summary>
+
+### search_history_path
+
+#### 功能说明
+
+指定弹幕搜索历史记录文件的路径，支持绝对路径和相对路径。默认值是 `~~/danmaku-search-history.json` 也就是mpv配置文件夹的根目录下。
+
+开启后，搜索过的弹幕关键词会记录在搜索菜单中（去重置顶，最近使用的排在最前），下次打开搜索菜单时可以直接选择历史关键词重新搜索，无需重复输入。
+
+> **⚠️NOTE！**
+> 
+> 留空此选项可禁用搜索历史功能
+
+#### 使用示例
+
+想要配置此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并添加类似如下内容：
+
+```
+search_history_path=/path/to/your/danmaku-search-history.json
+```
+
+</details>
+
+---
+
+<details>
+<summary>
+search_history_size
+
+> 指定搜索历史最多保留的条数
+
+</summary>
+
+### search_history_size
+
+#### 功能说明
+
+指定搜索历史最多保留的条数。超出上限时从最早的记录开始丢弃，默认值为 `15`，小于 1 表示不限制。
+
+#### 使用示例
+
+想要配置此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并添加类似如下内容：
+
+```
+search_history_size=30
+```
+
+</details>
+
+---
+
 ### 自定义弹幕样式相关配置
 
 默认配置如下，可根据需求更改并自定义弹幕样式

--- a/modules/menu.lua
+++ b/modules/menu.lua
@@ -510,11 +510,46 @@ end
 function open_input_menu_get()
     mp.commandv('script-message-to', 'console', 'disable')
     local title = parse_title()
+    local history_items = get_search_history()
+
+    local function build_log(select_text)
+        local log = {
+            { text = "【弹幕搜索】", style = "{\\c&H00CCFF&\\b1}" },
+            { text = "提示: 回车进行搜索", style = "{\\c&H999999&}" },
+        }
+        if #history_items > 0 then
+            table.insert(log, { text = "【搜索历史】", style = "{\\c&H00CCFF&\\b1}" })
+            for i, item in ipairs(history_items) do
+                local text = string.format("  [%02d] %s", i, item.keyword)
+                if item.time > 0 then
+                    text = text .. string.format("  [%s]", os.date("%Y/%m/%d %H:%M", item.time))
+                end
+                local style = (tonumber(select_text) == i) and "{\\c&HFFDE7F&\\b1}" or "{\\c&HCCCCCC&}"
+                table.insert(log, { text = text, style = style })
+            end
+            table.insert(log, { text = string.format("提示: 输入【1-%d】可快速重新搜索对应关键词", #history_items), style = "{\\c&H999999&}" })
+        end
+        input.set_log(log)
+    end
+
     input_open({
         prompt = '番剧名称:',
         default_text = title,
         cursor_position = title and #title + 1,
+        opened = function() build_log() end,
+        edited = function(text)
+            text = text:gsub("^%s*(.-)%s*$", "%1")
+            build_log(text ~= "" and text or nil)
+        end,
         submit = function(text)
+            text = text:gsub("^%s*(.-)%s*$", "%1")
+
+            -- 输入历史编号则替换为对应关键词重搜
+            local num = tonumber(text)
+            if num and history_items[num] then
+                text = history_items[num].keyword
+            end
+
             input.terminate()
             mp.commandv("script-message-to", mp.get_script_name(), "search-anime-event", text)
         end
@@ -541,6 +576,18 @@ function open_input_menu_uosc()
         keep_open = true,
         selectable = false,
     }
+
+    -- 追加搜索历史条目，点击直接重新搜索
+    for _, item in ipairs(get_search_history()) do
+        items[#items + 1] = {
+            title = item.keyword,
+            hint = item.time > 0 and os.date("%Y/%m/%d %H:%M", item.time) or nil,
+            icon = "history",
+            value = { "script-message-to", mp.get_script_name(), "search-anime-event", item.keyword },
+            keep_open = false,
+            selectable = true,
+        }
+    end
 
     local menu_props = {
         type = "menu_danmaku",
@@ -1444,6 +1491,7 @@ end)
 
 -- 注册函数给 uosc 按钮使用
 mp.register_script_message("search-anime-event", function(query)
+    record_search_history(query)
     perform_cancel_active_request()
     if uosc_available then
         mp.commandv("script-message-to", "uosc", "close-menu", "menu_danmaku")

--- a/modules/options.lua
+++ b/modules/options.lua
@@ -47,6 +47,10 @@ options = {
     merge_fontsize_max = 100,
     -- 指定弹幕关联历史记录文件的路径，支持绝对路径和相对路径
     history_path = "~~/danmaku-history.json",
+    -- 指定弹幕搜索历史记录文件的路径，支持绝对路径和相对路径。留空禁用搜索历史功能
+    search_history_path = "~~/danmaku-search-history.json",
+    -- 搜索历史最多保留的条数，小于 1 表示不限制
+    search_history_size = 15,
     -- 自定义插件快捷键，若 mpv.conf 里设置 input-default-bindings=no 将禁用以下两个选项
     open_search_danmaku_menu_key = "Ctrl+d",
     show_danmaku_keyboard_key = "j",

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -1,3 +1,4 @@
+local msg = require('mp.msg')
 local utils = require("mp.utils")
 local unpack = unpack or table.unpack
 
@@ -994,4 +995,89 @@ function parallel_requests(servers, build_args_fn, per_response_cb, final_cb, op
             monitor = nil
         end
     end
+end
+
+-- ============== 弹幕搜索历史 ==============
+
+local search_history_records = nil
+
+function get_search_history_path()
+    local path = options.search_history_path
+    if path == nil or path == "" then return nil end
+    return mp.command_native({"expand-path", path})
+end
+
+function load_search_history()
+    if search_history_records ~= nil then
+        return search_history_records
+    end
+
+    search_history_records = {}
+    local path = get_search_history_path()
+    if path == nil then return search_history_records end
+
+    local content = read_file(path)
+    if content == nil then return search_history_records end
+
+    local data = utils.parse_json(content)
+    if type(data) ~= "table" then
+        msg.warn("搜索历史文件解析失败，已忽略: " .. path)
+        return search_history_records
+    end
+
+    for _, item in ipairs(data) do
+        if type(item) == "table" and type(item.keyword) == "string" and item.keyword ~= "" then
+            table.insert(search_history_records, {
+                keyword = item.keyword,
+                time = tonumber(item.time) or 0,
+            })
+        end
+    end
+
+    return search_history_records
+end
+
+function save_search_history()
+    local path = get_search_history_path()
+    if path then
+        write_json_file(path, search_history_records)
+    end
+end
+
+function record_search_history(query)
+    local path = get_search_history_path()
+    if path == nil or type(query) ~= "string" then return end
+
+    query = query:gsub("^%s*(.-)%s*$", "%1")
+    if query == "" then return end
+
+    local records = load_search_history()
+
+    -- 去重：已存在的记录先移除，新记录插入头部置顶
+    for i, item in ipairs(records) do
+        if item.keyword == query then
+            table.remove(records, i)
+            break
+        end
+    end
+    table.insert(records, 1, { keyword = query, time = os.time() })
+
+    -- 超过上限时从尾部丢弃，小于 1 表示不限制
+    local size = tonumber(options.search_history_size) or 15
+    if size >= 1 then
+        while #records > size do
+            table.remove(records)
+        end
+    end
+
+    save_search_history()
+end
+
+function get_search_history()
+    return load_search_history()
+end
+
+function clear_search_history()
+    search_history_records = {}
+    save_search_history()
 end


### PR DESCRIPTION
Resolves #414

原本初次加载完之后，可以使用快捷键快速加载上次的弹幕，添加此功能为添加一个备选，可能有点重复造轮子了

## 功能

为弹幕搜索增加历史记录功能：

- 搜索过的关键词自动记录，去重置顶，最近使用的排在最前
- 打开搜索菜单时可直接选用历史关键词重搜，无需重复输入
- uosc 菜单与无 uosc（mp.input）环境均支持，行为一致
- 记录原始输入（含 `|ds`、`@服务器备注` 等后缀），重搜与手动输入行为一致

## 改动

实现参考了 #414 中的反馈意见，未新增模块，函数置于 `modules/utils.lua`：

- `modules/utils.lua`：新增搜索历史函数组（加载/记录/读取/清空）
- `modules/menu.lua`：搜索菜单展示历史（uosc 为可点击条目，mp.input 为编号重搜）
- `modules/options.lua`：新增 `search_history_path`、`search_history_size`
- `README.md`：补充两个配置项的文档

全部为纯新增改动（196 行，0 删除），不影响现有功能。

## 配置

- `search_history_path`：历史文件路径，默认 `~~/danmaku-search-history.json`，留空禁用
- `search_history_size`：最多保留条数，默认 `15`，小于 1 不限制

## 测试

- [x] uosc 环境：历史条目展示、点击重搜、记录置顶
- [x] 无 uosc 环境：编号重搜、关键词记录
- [ ] `search_history_path` 留空时功能静默禁用
- [ ] 历史文件损坏时降级处理
